### PR TITLE
Parse platform_id from TripUpdates_enhance.json

### DIFF
--- a/lib/concentrate/encoder/trip_updates_enhanced.ex
+++ b/lib/concentrate/encoder/trip_updates_enhanced.ex
@@ -62,7 +62,8 @@ defmodule Concentrate.Encoder.TripUpdatesEnhanced do
       arrival: stop_time_event(StopTimeUpdate.arrival_time(update)),
       departure: stop_time_event(StopTimeUpdate.departure_time(update)),
       schedule_relationship: StopTimeUpdate.schedule_relationship(update),
-      boarding_status: StopTimeUpdate.status(update)
+      boarding_status: StopTimeUpdate.status(update),
+      platform_id: StopTimeUpdate.platform_id(update)
     })
   end
 

--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -49,7 +49,8 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
           schedule_relationship: stu["schedule_relationship"],
           arrival_time: time_from_event(stu["arrival"]),
           departure_time: time_from_event(stu["departure"]),
-          status: boarding_status(stu["boarding_status"])
+          status: boarding_status(stu["boarding_status"]),
+          platform_id: stu["platform_id"]
         )
       end
 

--- a/lib/concentrate/stop_time_update.ex
+++ b/lib/concentrate/stop_time_update.ex
@@ -12,6 +12,7 @@ defmodule Concentrate.StopTimeUpdate do
     :stop_sequence,
     :status,
     :track,
+    :platform_id,
     schedule_relationship: :SCHEDULED
   ])
 
@@ -40,7 +41,8 @@ defmodule Concentrate.StopTimeUpdate do
               second.schedule_relationship
             else
               first.schedule_relationship
-            end
+            end,
+          platform_id: first.platform_id || second.platform_id
       }
     end
 

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -78,5 +78,19 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
       [_tu, stop_update] = decode_trip_update(update)
       assert StopTimeUpdate.status(stop_update) == :ALL_ABOARD
     end
+
+    test "can handle platform id information" do
+      update = %{
+        "trip" => %{},
+        "stop_time_update" => [
+          %{
+            "platform_id" => "platform"
+          }
+        ]
+      }
+
+      [_tu, stop_update] = decode_trip_update(update)
+      assert StopTimeUpdate.platform_id(stop_update) == "platform"
+    end
   end
 end

--- a/test/concentrate/stop_time_update_test.exs
+++ b/test/concentrate/stop_time_update_test.exs
@@ -13,7 +13,8 @@ defmodule Concentrate.StopTimeUpdateTest do
           stop_sequence: 1,
           arrival_time: 2,
           departure_time: 3,
-          status: "status"
+          status: "status",
+          platform_id: "platform"
         )
 
       second =
@@ -36,7 +37,8 @@ defmodule Concentrate.StopTimeUpdateTest do
           departure_time: 4,
           status: "status",
           track: "track",
-          schedule_relationship: :SKIPPED
+          schedule_relationship: :SKIPPED,
+          platform_id: "platform"
         )
 
       assert Mergeable.merge(first, second) == expected


### PR DESCRIPTION
Why:

* To include platform_id in output.
* Asana link: https://app.asana.com/0/516686971504018/518860404232401

This change addresses the need by:

* Editing `Concentrate.Parser.GTFSRealtimeEnhanced` to
  support stop_time_update's `platform_id`.
* Editing `Concentrate.StopTimeUpdate` to include `platform_id` in the
  output of `merge/2`.
* Editing `Concentrate.Encoder.TripUpdatesEnhanced` to include
  `platform_id` in output.