### PR TITLE
remove shuttle updates before the vehicle starts on the route

### DIFF
--- a/lib/concentrate/merge_filter.ex
+++ b/lib/concentrate/merge_filter.ex
@@ -11,7 +11,7 @@ defmodule Concentrate.MergeFilter do
   use GenStage
   require Logger
   alias Concentrate.Merge.Table
-  alias Concentrate.Filter
+  alias Concentrate.{Filter, TripUpdate, VehiclePosition, StopTimeUpdate}
   @start_link_opts [:name]
 
   defstruct timeout: 1_000,
@@ -92,7 +92,13 @@ defmodule Concentrate.MergeFilter do
       "#{__MODULE__} merge took #{time / 1_000}ms"
     end)
 
-    {time, filtered} = :timer.tc(Filter, :run, [merged, state.filters])
+    {time, sorted} = :timer.tc(Enum, :sort_by, [merged, &sort_key/1])
+
+    Logger.debug(fn ->
+      "#{__MODULE__} sort took #{time / 1_000}ms"
+    end)
+
+    {time, filtered} = :timer.tc(Filter, :run, [sorted, state.filters])
 
     Logger.debug(fn ->
       "#{__MODULE__} filter took #{time / 1_000}ms"
@@ -120,4 +126,9 @@ defmodule Concentrate.MergeFilter do
       end
     end
   end
+
+  defp sort_key(%TripUpdate{}), do: 0
+  defp sort_key(%VehiclePosition{}), do: 1
+  defp sort_key(%StopTimeUpdate{}), do: 2
+  defp sort_key(_), do: 4
 end

--- a/test/concentrate/filter/shuttle_test.exs
+++ b/test/concentrate/filter/shuttle_test.exs
@@ -52,7 +52,13 @@ defmodule Concentrate.Filter.ShuttleTest do
         @vehicle,
         StopTimeUpdate.new(
           trip_id: @trip_id,
+          stop_id: "before_before_shuttle",
+          departure_time: @valid_date_time
+        ),
+        StopTimeUpdate.new(
+          trip_id: @trip_id,
           stop_id: "before_shuttle",
+          arrival_time: @valid_date_time,
           departure_time: @valid_date_time
         ),
         StopTimeUpdate.new(
@@ -75,7 +81,8 @@ defmodule Concentrate.Filter.ShuttleTest do
       ]
 
       reduced = run(updates)
-      assert [_tu, _vp, before, one, two, after_shuttle] = reduced
+      assert [_tu, _vp, before_before, before, one, two, after_shuttle] = reduced
+      assert StopTimeUpdate.schedule_relationship(before_before) == :SCHEDULED
       assert StopTimeUpdate.schedule_relationship(before) == :SCHEDULED
       assert StopTimeUpdate.schedule_relationship(one) == :SKIPPED
       assert StopTimeUpdate.schedule_relationship(two) == :SKIPPED
@@ -247,6 +254,16 @@ defmodule Concentrate.Filter.ShuttleTest do
 
       reduced = run(updates)
       assert [_tu] = reduced
+    end
+
+    test "updates on non-shuttles trips are not modified" do
+      updates = [
+        StopTimeUpdate.new(trip_id: "other_trip", stop_id: "1", departure_time: @valid_date_time),
+        StopTimeUpdate.new(trip_id: "other_trip", stop_id: "2", arrival_time: @valid_date_time)
+      ]
+
+      reduced = run(updates)
+      assert updates == reduced
     end
 
     test "other values are returned as-is" do


### PR DESCRIPTION
asana: https://app.asana.com/0/505721188639414/510039796888298

The rationale for this is to avoid making incorrect predictions for vehicles on the opposite side of a shuttle:
```
A <-> B <shuttle> C <-> D
```

For many prediction systems, a train on an `A -> D` trip will have predictions made for a return `D -> A` trip on the same block. However, since we know the train won't move past the shuttle, we want to remove the `D -> A` trip predictions.