### PR TITLE
Adds TripUpdates.json encoder

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,6 +38,7 @@ config :concentrate,
   encoders: [
     files: [
       {"TripUpdates.pb", Concentrate.Encoder.TripUpdates},
+      {"TripUpdates.json", Concentrate.Encoder.TripUpdates.JSON},
       {"VehiclePositions.pb", Concentrate.Encoder.VehiclePositions},
       {"TripUpdates_enhanced.json", Concentrate.Encoder.TripUpdatesEnhanced}
     ]

--- a/lib/concentrate/encoder/trip_updates/json.ex
+++ b/lib/concentrate/encoder/trip_updates/json.ex
@@ -1,0 +1,17 @@
+defmodule Concentrate.Encoder.TripUpdates.JSON do
+  @moduledoc """
+  Encodes a list of parsed data into a TripUpdates.json file.
+  """
+  @behaviour Concentrate.Encoder
+  alias Concentrate.Encoder.TripUpdates
+
+  @impl Concentrate.Encoder
+  def encode(list) when is_list(list) do
+    message = %{
+      header: TripUpdates.feed_header(),
+      entity: TripUpdates.feed_entity(list)
+    }
+
+    Jason.encode!(message)
+  end
+end

--- a/test/concentrate/encoder/trip_updates/json_test.exs
+++ b/test/concentrate/encoder/trip_updates/json_test.exs
@@ -1,0 +1,41 @@
+defmodule Concentrate.Encoder.TripUpdates.JSONTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  import Concentrate.Encoder.TripUpdates.JSON
+  alias Concentrate.{TripUpdate, StopTimeUpdate}
+
+  describe "encode/1" do
+    test "same output as EncoderTripUpdates.encode/1 but in JSON" do
+      trip_updates = [
+        TripUpdate.new(trip_id: "1"),
+        TripUpdate.new(trip_id: "2"),
+        TripUpdate.new(trip_id: "3")
+      ]
+
+      stop_time_updates =
+        Enum.shuffle([
+          StopTimeUpdate.new(trip_id: "1"),
+          StopTimeUpdate.new(trip_id: "2"),
+          StopTimeUpdate.new(trip_id: "3")
+        ])
+
+      initial = trip_updates ++ stop_time_updates
+      %{"header" =>  _, "entity" => entity} =
+        initial
+        |> encode()
+        |> Jason.decode!
+
+      assert length(entity) == 3
+      assert List.first(entity) ==
+        %{"id" => "1",
+          "trip_update" => %{
+            "stop_time_update" => [%{"schedule_relationship" => "SCHEDULED"}],
+            "trip" => %{
+              "schedule_relationship" => "SCHEDULED",
+              "trip_id" => "1"
+            }
+          }
+        }
+    end
+  end
+end


### PR DESCRIPTION
Why:

* For trip updates to also be available in JSON.
* Asana link: https://app.asana.com/0/505721188639414/523237115785966

This change addresses the need by:

* Editing config to include a new encoder/file for generating
  TripUpdates.json files.
* Adding `Concentrate.Encoder.TripUpdates.JSON` which leverages
  `Concentrate.Encoder.TripUpdates` for the actual work. Only difference
  between `TripUpdates` and `TripUpdates.JSON` is that the latter
  returns JSON.