### PR TITLE
fallback URLs for the StateMachine

### DIFF
--- a/lib/concentrate/producer/http.ex
+++ b/lib/concentrate/producer/http.ex
@@ -84,7 +84,7 @@ defmodule Concentrate.Producer.HTTP do
     {time, parsed} = :timer.tc(state.parser, [binary])
 
     Logger.info(fn ->
-      "#{__MODULE__} updated: url=#{inspect(state.machine.url)} records=#{length(parsed)} time=#{
+      "#{__MODULE__} updated: url=#{inspect(SM.url(state.machine))} records=#{length(parsed)} time=#{
         time / 1000
       }"
     end)
@@ -98,7 +98,7 @@ defmodule Concentrate.Producer.HTTP do
 
   defp parse_error(error, state, trace) do
     Logger.error(fn ->
-      "#{__MODULE__}: #{inspect(state.machine.url)} parse error: #{inspect(error)}\n#{
+      "#{__MODULE__}: #{inspect(SM.url(state.machine))} parse error: #{inspect(error)}\n#{
         Exception.format_stacktrace(trace)
       }"
     end)

--- a/test/concentrate/supervisor/pipeline_test.exs
+++ b/test/concentrate/supervisor/pipeline_test.exs
@@ -11,7 +11,7 @@ defmodule Concentrate.Supervisor.PipelineTest do
         sources: [
           gtfs_realtime: [
             name: "url",
-            name2: "url2"
+            name2: {"url2", fallback_url: "url fallback"}
           ]
         ],
         reporters: [Concentrate.Reporter.VehicleLatency],

--- a/test/concentrate_test.exs
+++ b/test/concentrate_test.exs
@@ -18,7 +18,10 @@ defmodule ConcentrateTest do
   "sources": {
     "gtfs_realtime": {
       "name_1": "url_1",
-      "name_2": "url_2"
+      "name_2": {
+        "url": "url_2",
+        "fallback_url": "url_fallback"
+       }
     },
     "gtfs_realtime_enhanced": {
       "enhanced_1": "url_3"
@@ -42,7 +45,7 @@ defmodule ConcentrateTest do
 
       assert config[:sources][:gtfs_realtime] == %{
                name_1: "url_1",
-               name_2: "url_2"
+               name_2: {"url_2", fallback_url: "url_fallback"}
              }
 
       assert config[:sources][:gtfs_realtime_enhanced] == %{


### PR DESCRIPTION
For some URLs, there's a fallback URL we can use if the parent URL stops
updating. We implement this by having a child StateMachine that we can pass
messages to when we're in fallback mode.