### PR TITLE
allow filtering a feed to a maximum future time

### DIFF
--- a/lib/concentrate.ex
+++ b/lib/concentrate.ex
@@ -85,7 +85,11 @@ defmodule Concentrate do
 
   defp decode_gtfs_realtime_value(%{url: url} = value) when is_binary(url) do
     opts =
-      for {key, guard} <- [routes: &is_list/1, fallback_url: &is_binary/1],
+      for {key, guard} <- [
+            routes: &is_list/1,
+            fallback_url: &is_binary/1,
+            max_future_time: &is_integer/1
+          ],
           {:ok, opt_value} <- [Map.fetch(value, key)],
           guard.(opt_value) do
         {key, opt_value}

--- a/lib/concentrate/supervisor/pipeline.ex
+++ b/lib/concentrate/supervisor/pipeline.ex
@@ -29,7 +29,8 @@ defmodule Concentrate.Supervisor.Pipeline do
         {url, opts, parser} =
           case url do
             {url, opts} when is_binary(url) ->
-              {url, opts, {Concentrate.Parser.GTFSRealtime, Keyword.take(opts, [:routes])}}
+              {url, opts,
+               {Concentrate.Parser.GTFSRealtime, Keyword.take(opts, ~w(routes max_future_time)a)}}
 
             url when is_binary(url) ->
               {url, [], Concentrate.Parser.GTFSRealtime}

--- a/test/concentrate/parser/gtfs_realtime_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_test.exs
@@ -4,6 +4,7 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
   import Concentrate.TestHelpers
   import Concentrate.Parser.GTFSRealtime
   alias Concentrate.{VehiclePosition, TripUpdate, StopTimeUpdate, Alert}
+  alias Concentrate.Parser.GTFSRealtime.Options
 
   describe "parse/1" do
     test "parsing a vehiclepositions.pb file returns only VehiclePosition or TripUpdate structs" do
@@ -51,7 +52,7 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
         stop_time_update: []
       }
 
-      [tu] = decode_trip_update(update, [])
+      [tu] = decode_trip_update(update, %Options{})
 
       assert tu ==
                TripUpdate.new(
@@ -75,7 +76,7 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
         ]
       }
 
-      [_tu, stop_update] = decode_trip_update(update, [])
+      [_tu, stop_update] = decode_trip_update(update, %Options{})
       refute StopTimeUpdate.arrival_time(stop_update)
       refute StopTimeUpdate.departure_time(stop_update)
     end
@@ -90,7 +91,7 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
         ]
       }
 
-      assert [] = decode_trip_update(update, {:ok, ["keeping"]})
+      assert [] = decode_trip_update(update, %Options{routes: {:ok, ["keeping"]}})
     end
 
     test "includes trip/stop update if we're keeping the route" do
@@ -103,7 +104,7 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
         ]
       }
 
-      assert [_, _] = decode_trip_update(update, {:ok, ["keeping"]})
+      assert [_, _] = decode_trip_update(update, %Options{routes: {:ok, ["keeping"]}})
     end
   end
 
@@ -115,7 +116,7 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
         position: %{latitude: 1, longitude: 1}
       }
 
-      assert [] = decode_vehicle(position, {:ok, ["keeping"]})
+      assert [] = decode_vehicle(position, %Options{routes: {:ok, ["keeping"]}})
     end
 
     test "includes trip/vehicle if we're keeping the route" do
@@ -125,7 +126,7 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
         position: %{latitude: 1, longitude: 1}
       }
 
-      assert [_, _] = decode_vehicle(position, {:ok, ["keeping"]})
+      assert [_, _] = decode_vehicle(position, %Options{routes: {:ok, ["keeping"]}})
     end
   end
 end

--- a/test/concentrate_test.exs
+++ b/test/concentrate_test.exs
@@ -21,6 +21,14 @@ defmodule ConcentrateTest do
       "name_2": {
         "url": "url_2",
         "fallback_url": "url_fallback"
+      },
+      "name_3": {
+        "url": "url_3",
+        "routes": ["a", "b"]
+      },
+      "name_4": {
+        "url": "url_4",
+        "max_future_time": 3600
        }
     },
     "gtfs_realtime_enhanced": {
@@ -45,7 +53,9 @@ defmodule ConcentrateTest do
 
       assert config[:sources][:gtfs_realtime] == %{
                name_1: "url_1",
-               name_2: {"url_2", fallback_url: "url_fallback"}
+               name_2: {"url_2", fallback_url: "url_fallback"},
+               name_3: {"url_3", routes: ~w(a b)},
+               name_4: {"url_4", max_future_time: 3600}
              }
 
       assert config[:sources][:gtfs_realtime_enhanced] == %{


### PR DESCRIPTION
Some feeds make predictions well into the future, and we don't care about those predictions. This allows us to configure that time on a per-feed basis.