### PR TITLE
update deploy script to not stop the old service

### DIFF
--- a/semaphore/deploy.sh
+++ b/semaphore/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e -x -u
+set -e -u
 
 sudo pip install -U awscli
 
@@ -20,42 +20,38 @@ newcontainers=$(echo $taskdefinition | jq ".containerDefinitions | map(.image=\"
 aws ecs register-task-definition --region us-east-1 --family $awsenv --cli-input-json "$taskdefinition" --container-definitions "$newcontainers"
 newrevision=$(aws ecs describe-task-definition --region us-east-1 --task-definition $awsenv | jq '.taskDefinition.revision')
 
-function update_service_with_desired_count {
-    aws ecs update-service --region us-east-1 --cluster $APP --service $awsenv --desired-count $1
-}
-
-function no_tasks_are_running {
+function task_count_eq {
     local tasks
-    tasks=$(aws ecs list-tasks --region us-east-1 --cluster $APP --service $awsenv| jq '.taskArns')
-    [[ $tasks = '[]' ]]
+    task_count=$(aws ecs list-tasks --region us-east-1 --cluster $APP --service $awsenv| jq '.taskArns | length')
+    [[ $task_count = "$1" ]]
 }
 
 function exit_if_too_many_checks {
-  if [[ $checks -ge 6 ]]; then
+  if [[ $checks -ge 12 ]]; then
     exit 1
   fi
   sleep 5
   checks=$((checks+1))
 }
-# by setting the desired count to 0, ECS will kill the task that the ECS service is running
-# allowing us to update it and start the new one. Check every 5 seconds to see if it's dead
-# yet (AWS issues `docker stop` and it could take a moment to spin down). If it's still running
-# after several checks, something is wrong and the script should die.
-update_service_with_desired_count 0
+
+expected_count=$(aws ecs list-tasks --region us-east-1 --cluster $APP --service $awsenv| jq '.taskArns | length')
+
+aws ecs update-service --region us-east-1 --cluster $APP --service $awsenv --task-definition $awsenv:$newrevision
+if  [[ $expected_count = "0" ]]; then
+    echo Environment $APP:$awsenv is not running!
+    echo
+    echo We updated the definition: you can manually set the desired instances to 1.
+    exit 1
+fi
 
 checks=0
-until no_tasks_are_running; do
-    echo "tasks still running"
+while task_count_eq $expected_count; do
+    echo not yet started...
     exit_if_too_many_checks
 done
 
-# Update the ECS service to use the new revision of the task definition. Then update the desired
-# count back to 1, so the container instance starts up the task. Check periodically to see if the
-# task is running yet, and signal deploy failure if it doesn't start up in a reasonable time.
-aws ecs update-service --region us-east-1 --cluster $APP --service $awsenv --task-definition $awsenv:$newrevision
-update_service_with_desired_count 1
 checks=0
-while no_tasks_are_running; do
-    echo "no tasks running"
+until task_count_eq $expected_count; do
+    echo old task not stopped...
     exit_if_too_many_checks
 done


### PR DESCRIPTION
If we stop the old service, we'll stop producing new files. Instead, we spin
up the new instance and wait for it to take over from the previous service.