### PR TITLE
don't render SCHEDULED schedule_relationships

### DIFF
--- a/lib/concentrate/encoder/gtfs_realtime_helpers.ex
+++ b/lib/concentrate/encoder/gtfs_realtime_helpers.ex
@@ -70,6 +70,15 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
     )
   end
 
+  @doc """
+  Renders the schedule relationship field.
+
+  SCHEDULED is the default and is rendered as `nil`. Other relationships are
+  rendered as-is.
+  """
+  def schedule_relationship(:SCHEDULED), do: nil
+  def schedule_relationship(relationship), do: relationship
+
   defp group_by_trip_id(%TripUpdate{} = tu, map) do
     case TripUpdate.trip_id(tu) do
       nil ->

--- a/lib/concentrate/encoder/trip_updates.ex
+++ b/lib/concentrate/encoder/trip_updates.ex
@@ -45,7 +45,8 @@ defmodule Concentrate.Encoder.TripUpdates do
               direction_id: TripUpdate.direction_id(update),
               start_time: TripUpdate.start_time(update),
               start_date: encode_date(TripUpdate.start_date(update)),
-              schedule_relationship: TripUpdate.schedule_relationship(update)
+              schedule_relationship:
+                schedule_relationship(TripUpdate.schedule_relationship(update))
             }),
           stop_time_update: Enum.map(stus, &build_stop_time_update/1)
         }
@@ -63,7 +64,7 @@ defmodule Concentrate.Encoder.TripUpdates do
       stop_sequence: StopTimeUpdate.stop_sequence(update),
       arrival: stop_time_event(StopTimeUpdate.arrival_time(update)),
       departure: stop_time_event(StopTimeUpdate.departure_time(update)),
-      schedule_relationship: StopTimeUpdate.schedule_relationship(update)
+      schedule_relationship: schedule_relationship(StopTimeUpdate.schedule_relationship(update))
     })
   end
 

--- a/lib/concentrate/encoder/trip_updates_enhanced.ex
+++ b/lib/concentrate/encoder/trip_updates_enhanced.ex
@@ -43,7 +43,8 @@ defmodule Concentrate.Encoder.TripUpdatesEnhanced do
               direction_id: TripUpdate.direction_id(update),
               start_time: TripUpdate.start_time(update),
               start_date: encode_date(TripUpdate.start_date(update)),
-              schedule_relationship: TripUpdate.schedule_relationship(update)
+              schedule_relationship:
+                schedule_relationship(TripUpdate.schedule_relationship(update))
             }),
           stop_time_update: Enum.map(stus, &build_stop_time_update/1)
         }
@@ -61,7 +62,7 @@ defmodule Concentrate.Encoder.TripUpdatesEnhanced do
       stop_sequence: StopTimeUpdate.stop_sequence(update),
       arrival: stop_time_event(StopTimeUpdate.arrival_time(update)),
       departure: stop_time_event(StopTimeUpdate.departure_time(update)),
-      schedule_relationship: StopTimeUpdate.schedule_relationship(update),
+      schedule_relationship: schedule_relationship(StopTimeUpdate.schedule_relationship(update)),
       boarding_status: StopTimeUpdate.status(update),
       platform_id: StopTimeUpdate.platform_id(update)
     })
@@ -76,4 +77,7 @@ defmodule Concentrate.Encoder.TripUpdatesEnhanced do
       time: unix_timestamp
     }
   end
+
+  defp schedule_relationship(:SCHEDULED), do: nil
+  defp schedule_relationship(relationship), do: relationship
 end

--- a/lib/concentrate/encoder/trip_updates_enhanced.ex
+++ b/lib/concentrate/encoder/trip_updates_enhanced.ex
@@ -77,7 +77,4 @@ defmodule Concentrate.Encoder.TripUpdatesEnhanced do
       time: unix_timestamp
     }
   end
-
-  defp schedule_relationship(:SCHEDULED), do: nil
-  defp schedule_relationship(relationship), do: relationship
 end

--- a/test/concentrate/encoder/trip_updates/json_test.exs
+++ b/test/concentrate/encoder/trip_updates/json_test.exs
@@ -7,14 +7,14 @@ defmodule Concentrate.Encoder.TripUpdates.JSONTest do
   describe "encode/1" do
     test "same output as EncoderTripUpdates.encode/1 but in JSON" do
       trip_updates = [
-        TripUpdate.new(trip_id: "1"),
+        TripUpdate.new(trip_id: "1", schedule_relationship: :ADDED),
         TripUpdate.new(trip_id: "2"),
         TripUpdate.new(trip_id: "3")
       ]
 
       stop_time_updates =
         Enum.shuffle([
-          StopTimeUpdate.new(trip_id: "1"),
+          StopTimeUpdate.new(trip_id: "1", schedule_relationship: :SKIPPED),
           StopTimeUpdate.new(trip_id: "2"),
           StopTimeUpdate.new(trip_id: "3")
         ])
@@ -32,13 +32,36 @@ defmodule Concentrate.Encoder.TripUpdates.JSONTest do
                %{
                  "id" => "1",
                  "trip_update" => %{
-                   "stop_time_update" => [%{"schedule_relationship" => "SCHEDULED"}],
+                   "stop_time_update" => [%{"schedule_relationship" => "SKIPPED"}],
                    "trip" => %{
-                     "schedule_relationship" => "SCHEDULED",
+                     "schedule_relationship" => "ADDED",
                      "trip_id" => "1"
                    }
                  }
                }
+    end
+
+    test "trips/updates with schedule_relationship SCHEDULED don't have that field" do
+      parsed = [
+        TripUpdate.new(trip_id: "trip", schedule_relationship: :SCHEDULED),
+        StopTimeUpdate.new(trip_id: "trip", stop_id: "stop", schedule_relationship: :SCHEDULED)
+      ]
+
+      encoded = Jason.decode!(encode(parsed))
+
+      %{
+        "entity" => [
+          %{
+            "trip_update" => %{
+              "trip" => trip,
+              "stop_time_update" => [update]
+            }
+          }
+        ]
+      } = encoded
+
+      refute "schedule_relationship" in Map.keys(trip)
+      refute "schedule_relationship" in Map.keys(update)
     end
   end
 end

--- a/test/concentrate/encoder/trip_updates_enhanced_test.exs
+++ b/test/concentrate/encoder/trip_updates_enhanced_test.exs
@@ -49,5 +49,28 @@ defmodule Concentrate.Encoder.TripUpdatesEnhancedTest do
       decoded = Jason.decode!(encode(initial))
       assert decoded["entity"] == []
     end
+
+    test "trips/updates with schedule_relationship SCHEDULED don't have that field" do
+      parsed = [
+        TripUpdate.new(trip_id: "trip", schedule_relationship: :SCHEDULED),
+        StopTimeUpdate.new(trip_id: "trip", stop_id: "stop", schedule_relationship: :SCHEDULED)
+      ]
+
+      encoded = Jason.decode!(encode(parsed))
+
+      %{
+        "entity" => [
+          %{
+            "trip_update" => %{
+              "trip" => trip,
+              "stop_time_update" => [update]
+            }
+          }
+        ]
+      } = encoded
+
+      refute "schedule_relationship" in Map.keys(trip)
+      refute "schedule_relationship" in Map.keys(update)
+    end
   end
 end


### PR DESCRIPTION
Most are scheduled, so we don't need to include the extra data.