### PR TITLE
better handling for `{:ssl_closed, _}` errors

### DIFF
--- a/lib/concentrate/producer/http/state_machine.ex
+++ b/lib/concentrate/producer/http/state_machine.ex
@@ -197,6 +197,11 @@ defmodule Concentrate.Producer.HTTP.StateMachine do
     {machine, [], []}
   end
 
+  defp handle_message(machine, {:ssl_closed, _} = message) do
+    # treat it as a regular HTTP error
+    handle_message(machine, {:http_error, message})
+  end
+
   defp handle_message(machine, unknown) do
     Logger.error(fn ->
       "#{__MODULE__}: #{inspect(machine.url)} got unexpected message: #{inspect(unknown)}"
@@ -307,6 +312,7 @@ defmodule Concentrate.Producer.HTTP.StateMachine do
 
   defp error_log_level(:closed), do: :warn
   defp error_log_level({:closed, _}), do: :warn
+  defp error_log_level({:ssl_closed, _}), do: :warn
   defp error_log_level(:timeout), do: :warn
   defp error_log_level(_), do: :error
 

--- a/lib/concentrate/sink/s3.ex
+++ b/lib/concentrate/sink/s3.ex
@@ -31,6 +31,27 @@ defmodule Concentrate.Sink.S3 do
     {:noreply, [], state}
   end
 
+  @impl GenStage
+  def handle_info({:ssl_closed, _}, state) do
+    Logger.info(fn ->
+      "#{__MODULE__} SSL closed error bucket=#{inspect(state.bucket)} prefix=#{
+        inspect(state.prefix)
+      }"
+    end)
+
+    {:noreply, [], state}
+  end
+
+  def handle_info(message, state) do
+    Logger.warn(fn ->
+      "#{__MODULE__} unexpected message bucket=#{inspect(state.bucket)} prefix=#{
+        inspect(state.prefix)
+      } message=#{inspect(message)}"
+    end)
+
+    {:noreply, [], state}
+  end
+
   defp upload_to_s3({filename, body}, state) do
     full_filename = Path.join(state.prefix, filename)
     opts = [acl: state.acl, content_type: content_type(filename)]

--- a/test/concentrate/producer/http/state_machine_test.exs
+++ b/test/concentrate/producer/http/state_machine_test.exs
@@ -79,6 +79,19 @@ defmodule Concentrate.Producer.HTTP.StateMachineTest do
       end
     end
 
+    test "does not log an error on :ssl_closed errors" do
+      machine = init("url", [])
+
+      error = {:ssl_closed, :closed}
+
+      log =
+        capture_log([level: :error], fn ->
+          assert {_machine, [], [{{:fetch, _}, _}]} = message(machine, error)
+        end)
+
+      assert log == ""
+    end
+
     test "does log other errors" do
       machine = init("url", [])
       error = {:http_error, :unknown_error}


### PR DESCRIPTION
We get these occasionally (see https://github.com/benoitc/hackney/issues/464). In the meantime, we can treat them as other kinds of `closed` errors.

* `HTTP.StateMachine`: retry the fetch
* `Sink.S3` log a warning, but don't retry

asana: https://app.asana.com/0/116562505129567/471912272390965