### PR TITLE
remove `init/0` callback from Filter

### DIFF
--- a/lib/concentrate/filter/closed_stop.ex
+++ b/lib/concentrate/filter/closed_stop.ex
@@ -8,12 +8,12 @@ defmodule Concentrate.Filter.ClosedStop do
   alias Concentrate.Filter.GTFS.Trips
 
   @impl Concentrate.Filter
-  def init do
-    {ClosedStops, Trips}
-  end
+  @modules {ClosedStops, Trips}
 
   @impl Concentrate.Filter
-  def filter(%StopTimeUpdate{} = stu, {stops_module, trips_module} = modules) do
+  def filter(update, modules \\ @modules)
+
+  def filter(%StopTimeUpdate{} = stu, {stops_module, trips_module}) do
     time = StopTimeUpdate.arrival_time(stu) || StopTimeUpdate.departure_time(stu)
 
     stu =
@@ -24,11 +24,11 @@ defmodule Concentrate.Filter.ClosedStop do
         update_stu_from_closed_entities(stu, entities, trips_module)
       end
 
-    {:cont, stu, modules}
+    {:cont, stu}
   end
 
-  def filter(other, modules) do
-    {:cont, other, modules}
+  def filter(other, _modules) do
+    {:cont, other}
   end
 
   defp update_stu_from_closed_entities(stu, [], _) do

--- a/lib/concentrate/filter/include_route_direction.ex
+++ b/lib/concentrate/filter/include_route_direction.ex
@@ -7,19 +7,16 @@ defmodule Concentrate.Filter.IncludeRouteDirection do
   alias Concentrate.Filter.GTFS.Trips
 
   @impl Concentrate.Filter
-  def init do
-    Trips
-  end
+  def filter(item, module \\ Trips)
 
-  @impl Concentrate.Filter
   def filter(%TripUpdate{} = tu, module) do
     trip_id = TripUpdate.trip_id(tu)
     tu = update_route_direction(tu, trip_id, module)
-    {:cont, tu, module}
+    {:cont, tu}
   end
 
-  def filter(other, state) do
-    {:cont, other, state}
+  def filter(other, _module) do
+    {:cont, other}
   end
 
   defp update_route_direction(tu, nil, _) do

--- a/lib/concentrate/filter/round_speed_to_integer.ex
+++ b/lib/concentrate/filter/round_speed_to_integer.ex
@@ -6,12 +6,7 @@ defmodule Concentrate.Filter.RoundSpeedToInteger do
   alias Concentrate.VehiclePosition
 
   @impl Concentrate.Filter
-  def init do
-    []
-  end
-
-  @impl Concentrate.Filter
-  def filter(%VehiclePosition{} = vp, state) do
+  def filter(%VehiclePosition{} = vp) do
     speed =
       case VehiclePosition.speed(vp) do
         nil -> nil
@@ -26,10 +21,10 @@ defmodule Concentrate.Filter.RoundSpeedToInteger do
         nil
       end
 
-    {:cont, VehiclePosition.update(vp, %{speed: speed, bearing: bearing}), state}
+    {:cont, VehiclePosition.update(vp, %{speed: speed, bearing: bearing})}
   end
 
-  def filter(other, state) do
-    {:cont, other, state}
+  def filter(other) do
+    {:cont, other}
   end
 end

--- a/lib/concentrate/filter/vehicle_with_no_trip.ex
+++ b/lib/concentrate/filter/vehicle_with_no_trip.ex
@@ -6,20 +6,15 @@ defmodule Concentrate.Filter.VehicleWithNoTrip do
   @behaviour Concentrate.Filter
 
   @impl Concentrate.Filter
-  def init do
-    []
-  end
-
-  @impl Concentrate.Filter
-  def filter(%VehiclePosition{} = vp, state) do
+  def filter(%VehiclePosition{} = vp) do
     if VehiclePosition.trip_id(vp) do
-      {:cont, vp, state}
+      {:cont, vp}
     else
-      {:skip, state}
+      :skip
     end
   end
 
-  def filter(other, state) do
-    {:cont, other, state}
+  def filter(other) do
+    {:cont, other}
   end
 end

--- a/test/concentrate/filter/closed_stop_test.exs
+++ b/test/concentrate/filter/closed_stop_test.exs
@@ -7,12 +7,12 @@ defmodule Concentrate.Filter.ClosedStopTest do
   @valid_date_time 8
   @invalid_date_time 4
 
-  @state {Concentrate.Filter.FakeClosedStops, Concentrate.Filter.FakeTrips}
+  @modules {Concentrate.Filter.FakeClosedStops, Concentrate.Filter.FakeTrips}
 
   describe "filter/2" do
     test "unknown stop IDs are ignored" do
       stu = StopTimeUpdate.new(stop_id: "unknown", departure_time: @valid_date_time)
-      assert {:cont, ^stu, _} = filter(stu, @state)
+      assert {:cont, ^stu} = filter(stu, @modules)
     end
 
     test "skips the stop time if the stop is closed during the timeframe" do
@@ -24,7 +24,7 @@ defmodule Concentrate.Filter.ClosedStopTest do
           departure_time: @valid_date_time
         )
 
-      assert {:cont, new_stu, _} = filter(stu, @state)
+      assert {:cont, new_stu} = filter(stu, @modules)
       assert StopTimeUpdate.schedule_relationship(new_stu) == :SKIPPED
       assert StopTimeUpdate.arrival_time(new_stu) == nil
       assert StopTimeUpdate.departure_time(new_stu) == nil
@@ -38,7 +38,7 @@ defmodule Concentrate.Filter.ClosedStopTest do
           departure_time: @invalid_date_time
         )
 
-      assert {:cont, ^stu, _} = filter(stu, @state)
+      assert {:cont, ^stu} = filter(stu, @modules)
     end
 
     test "does not skip the stop time if the stop is closed on a different route" do
@@ -49,7 +49,7 @@ defmodule Concentrate.Filter.ClosedStopTest do
           departure_time: @valid_date_time
         )
 
-      assert {:cont, ^stu, _} = filter(stu, @state)
+      assert {:cont, ^stu} = filter(stu, @modules)
     end
 
     test "does not modify the update if there are no times" do
@@ -59,11 +59,11 @@ defmodule Concentrate.Filter.ClosedStopTest do
           stop_id: "route_stop"
         )
 
-      assert {:cont, ^stu, _} = filter(stu, @state)
+      assert {:cont, ^stu} = filter(stu, @modules)
     end
 
     test "other values are returned as-is" do
-      assert {:cont, :value, _} = filter(:value, @state)
+      assert {:cont, :value} = filter(:value)
     end
   end
 end

--- a/test/concentrate/filter/include_route_direction_test.exs
+++ b/test/concentrate/filter/include_route_direction_test.exs
@@ -4,33 +4,33 @@ defmodule Concentrate.Filter.IncludeRouteDirectionTest do
   import Concentrate.Filter.IncludeRouteDirection
   alias Concentrate.TripUpdate
 
-  @state Concentrate.Filter.FakeTrips
+  @module Concentrate.Filter.FakeTrips
 
   describe "filter/2" do
     test "a trip update with a route/direction is kept as-is" do
       tu = TripUpdate.new(trip_id: "trip", route_id: "r", direction_id: 0)
-      assert {:cont, ^tu, _} = filter(tu, @state)
+      assert {:cont, ^tu} = filter(tu, @module)
     end
 
     test "a trip update without a trip is kept as-is" do
       tu = TripUpdate.new([])
-      assert {:cont, ^tu, _} = filter(tu, @state)
+      assert {:cont, ^tu} = filter(tu, @module)
     end
 
     test "a missing route/direction_id is updated" do
       tu = TripUpdate.new(trip_id: "trip")
-      assert {:cont, new_tu, _} = filter(tu, @state)
+      assert {:cont, new_tu} = filter(tu, @module)
       assert TripUpdate.route_id(new_tu) == "route"
       assert TripUpdate.direction_id(new_tu) == 1
     end
 
     test "unknown trip IDs are ignored" do
       tu = TripUpdate.new(trip_id: "unknown")
-      assert {:cont, ^tu, _} = filter(tu, @state)
+      assert {:cont, ^tu} = filter(tu, @module)
     end
 
     test "other values are returned as-is" do
-      assert {:cont, :value, _} = filter(:value, @state)
+      assert {:cont, :value} = filter(:value)
     end
   end
 end

--- a/test/concentrate/filter/round_speed_to_integer_test.exs
+++ b/test/concentrate/filter/round_speed_to_integer_test.exs
@@ -4,30 +4,28 @@ defmodule Concentrate.Filter.RoundSpeedToIntegerTest do
   import Concentrate.Filter.RoundSpeedToInteger
   alias Concentrate.VehiclePosition
 
-  @state init()
-
-  describe "filter/2" do
+  describe "filter/1" do
     test "a vehicle position with no speed or bearing is unchanged" do
       vp = VehiclePosition.new(latitude: 1, longitude: 1)
-      assert {:cont, ^vp, _} = filter(vp, @state)
+      assert {:cont, ^vp} = filter(vp)
     end
 
     test "a vehicle position with a float speed or bearing is truncated" do
       vp = VehiclePosition.new(speed: 1.5, bearing: -123.45, latitude: 1, longitude: 1)
-      {:cont, new_vp, _} = filter(vp, @state)
+      {:cont, new_vp} = filter(vp)
       assert VehiclePosition.speed(new_vp) == 1
       assert VehiclePosition.bearing(new_vp) == -123
     end
 
     test "small speeds (but not bearings) are converted to nil" do
       vp = VehiclePosition.new(speed: 0.5, bearing: 0.5, latitude: 1, longitude: 1)
-      {:cont, new_vp, _} = filter(vp, @state)
+      {:cont, new_vp} = filter(vp)
       assert VehiclePosition.speed(new_vp) == nil
       assert VehiclePosition.bearing(new_vp) == 0
     end
 
     test "other values are returned as-is" do
-      assert {:cont, :value, _} = filter(:value, @state)
+      assert {:cont, :value} = filter(:value)
     end
   end
 end

--- a/test/concentrate/filter/vehicle_with_no_trip_test.exs
+++ b/test/concentrate/filter/vehicle_with_no_trip_test.exs
@@ -4,21 +4,19 @@ defmodule Concentrate.Filter.VehicleWithNoTripTest do
   import Concentrate.Filter.VehicleWithNoTrip
   alias Concentrate.VehiclePosition
 
-  @state init()
-
-  describe "filter/2" do
+  describe "filter/1" do
     test "a vehicle position with a trip is kept" do
       vp = VehiclePosition.new(trip_id: "trip", latitude: 1, longitude: 1)
-      assert {:cont, ^vp, _} = filter(vp, @state)
+      assert {:cont, ^vp} = filter(vp)
     end
 
     test "a vehicle position without a trip is removed" do
       vp = VehiclePosition.new(latitude: 1, longitude: 1)
-      assert {:skip, _} = filter(vp, @state)
+      assert :skip = filter(vp)
     end
 
     test "other values are returned as-is" do
-      assert {:cont, :value, _} = filter(:value, @state)
+      assert {:cont, :value} = filter(:value)
     end
   end
 end


### PR DESCRIPTION
Now that the filters which need state are `GroupFilter`s, we can simplify the
implementation of `Filter` to not require additional state.