### PR TITLE
`Reporter`: work with trip groups instead of a list of parsed items

### DIFF
--- a/lib/concentrate/reporter.ex
+++ b/lib/concentrate/reporter.ex
@@ -9,12 +9,13 @@ defmodule Concentrate.Reporter do
   ## Callbacks
 
   * `init/0`: returns an initial state
-  * `log/2`: receives the list of filtered data and the current state;
+  * `log/2`: receives the list of trip groups and the current state;
     returns a keyword list of stats and the new state
   """
+  alias Concentrate.Encoder.GTFSRealtimeHelpers
   @type state :: term
   @type stats :: [{atom, term}]
 
   @callback init() :: state
-  @callback log([Concentrate.Parser.parsed()], state) :: {stats, state}
+  @callback log([GTFSRealtimeHelpers.trip_group()], state) :: {stats, state}
 end

--- a/lib/concentrate/reporter/latency.ex
+++ b/lib/concentrate/reporter/latency.ex
@@ -10,7 +10,7 @@ defmodule Concentrate.Reporter.Latency do
   end
 
   @impl Concentrate.Reporter
-  def log(_parsed, last_update) do
+  def log(_groups, last_update) do
     new_now = now()
     {[update_latency_ms: new_now - last_update], new_now}
   end

--- a/lib/concentrate/reporter/stop_time_update_latency.ex
+++ b/lib/concentrate/reporter/stop_time_update_latency.ex
@@ -11,8 +11,11 @@ defmodule Concentrate.Reporter.StopTimeUpdateLatency do
   end
 
   @impl Concentrate.Reporter
-  def log(parsed, state) do
-    {earliest_time, latest_time} = Enum.reduce(parsed, {:infinity, 0}, &timestamp/2)
+  def log(groups, state) do
+    {earliest_time, latest_time} =
+      groups
+      |> Enum.flat_map(&elem(&1, 2))
+      |> Enum.reduce({:infinity, 0}, &timestamp/2)
 
     earliest_time = optional_time(earliest_time, :infinity)
     latest_time = optional_time(latest_time, 0)

--- a/lib/concentrate/reporter/vehicle_latency.ex
+++ b/lib/concentrate/reporter/vehicle_latency.ex
@@ -11,9 +11,14 @@ defmodule Concentrate.Reporter.VehicleLatency do
   end
 
   @impl Concentrate.Reporter
-  def log(parsed, state) do
+  def log(groups, state) do
     now = utc_now()
-    latenesses = Enum.flat_map(parsed, &timestamp(&1, now))
+
+    latenesses =
+      groups
+      # get the vehicle positions
+      |> Enum.flat_map(&elem(&1, 1))
+      |> Enum.flat_map(&timestamp(&1, now))
 
     latest =
       if latenesses == [] do

--- a/lib/concentrate/supervisor/pipeline.ex
+++ b/lib/concentrate/supervisor/pipeline.ex
@@ -77,7 +77,7 @@ defmodule Concentrate.Supervisor.Pipeline do
     for module <- reporter_modules do
       child_spec(
         {Concentrate.Reporter.Consumer,
-         module: module, subscribe_to: [merge_filter: [max_demand: 1]]},
+         module: module, subscribe_to: [group_pc: [max_demand: 1]]},
         id: module
       )
     end

--- a/test/concentrate/reporter/latency_test.exs
+++ b/test/concentrate/reporter/latency_test.exs
@@ -6,10 +6,10 @@ defmodule Concentrate.Reporter.LatencyTest do
   describe "log/2" do
     test "logs number of milliseconds between calls" do
       state = init()
-      assert {[update_latency_ms: time], state} = log([], state)
+      assert {[update_latency_ms: time], state} = log([{nil, [], []}], state)
       assert_in_delta time, 0, 50
       :timer.sleep(100)
-      assert {[update_latency_ms: time], _} = log([], state)
+      assert {[update_latency_ms: time], _} = log([{nil, [], []}], state)
       assert_in_delta time, 100, 50
     end
   end

--- a/test/concentrate/reporter/stop_time_update_latency_test.exs
+++ b/test/concentrate/reporter/stop_time_update_latency_test.exs
@@ -5,14 +5,14 @@ defmodule Concentrate.Reporter.STopTimeUpdateLatencyTest do
   alias Concentrate.StopTimeUpdate
 
   describe "log/2" do
-    test "logs undefined if there aren't any vehicles with timestamps" do
+    test "logs undefined if there aren't any stop time updates with timestamps" do
       state = init()
 
       assert {[earliest_stop_time_update: :undefined, latest_stop_time_update: :undefined], _} =
                log([], state)
 
       assert {[earliest_stop_time_update: :undefined, latest_stop_time_update: :undefined], _} =
-               log([StopTimeUpdate.new([])], state)
+               log([{nil, [], [StopTimeUpdate.new([])]}], state)
     end
 
     test "logs the difference with utc_now from the most-up-to-date vehicle" do
@@ -20,15 +20,18 @@ defmodule Concentrate.Reporter.STopTimeUpdateLatencyTest do
       stu = StopTimeUpdate.new([])
       now = utc_now()
 
-      vehicles = [
-        StopTimeUpdate.update_arrival_time(stu, now - 5),
-        StopTimeUpdate.update_departure_time(stu, now - 3),
-        StopTimeUpdate.update(stu, arrival_time: now + 1, departure_time: now + 2),
-        Concentrate.TripUpdate.new([])
-      ]
+      group = {
+        Concentrate.TripUpdate.new([]),
+        [],
+        [
+          StopTimeUpdate.update_arrival_time(stu, now - 5),
+          StopTimeUpdate.update_departure_time(stu, now - 3),
+          StopTimeUpdate.update(stu, arrival_time: now + 1, departure_time: now + 2)
+        ]
+      }
 
       assert {[earliest_stop_time_update: -5, latest_stop_time_update: 1], _} =
-               log(vehicles, state)
+               log([group], state)
     end
   end
 

--- a/test/concentrate/reporter/vehicle_latency_test.exs
+++ b/test/concentrate/reporter/vehicle_latency_test.exs
@@ -14,9 +14,10 @@ defmodule Concentrate.Reporter.VehicleLatencyTest do
         vehicle_count: 0
       ]
 
-      assert {^expected, _} = log([], state)
+      assert {^expected, _} = log([{nil, [], []}], state)
 
-      assert {^expected, _} = log([VehiclePosition.new(latitude: 1, longitude: 1)], state)
+      assert {^expected, _} =
+               log([{nil, [VehiclePosition.new(latitude: 1, longitude: 1)], []}], state)
     end
 
     test "logs the difference with utc_now from the most-up-to-date vehicle" do
@@ -24,12 +25,15 @@ defmodule Concentrate.Reporter.VehicleLatencyTest do
       vp = VehiclePosition.new(latitude: 1, longitude: 1)
       now = utc_now()
 
-      vehicles = [
-        VehiclePosition.update_last_updated(vp, now - 5),
-        VehiclePosition.update_last_updated(vp, now - 3),
-        VehiclePosition.update_last_updated(vp, now - 10),
-        Concentrate.TripUpdate.new([])
-      ]
+      group = {
+        Concentrate.TripUpdate.new([]),
+        [
+          VehiclePosition.update_last_updated(vp, now - 5),
+          VehiclePosition.update_last_updated(vp, now - 3),
+          VehiclePosition.update_last_updated(vp, now - 10)
+        ],
+        []
+      }
 
       average_lateness = (5 + 3 + 10) / 3
 
@@ -39,7 +43,7 @@ defmodule Concentrate.Reporter.VehicleLatencyTest do
         vehicle_count: 3
       ]
 
-      assert {^expected, _} = log(vehicles, state)
+      assert {^expected, _} = log([group], state)
     end
   end
 


### PR DESCRIPTION
Since there's additional filtering happening after the grouping, the
reporters weren't aware of it. By having the reporters work on grouped data,
they receive it only after all the filtering happens.