### PR TITLE
fix for TripUpdate w/o StopTimeUpdates

### DIFF
--- a/lib/concentrate/parser/gtfs_realtime.ex
+++ b/lib/concentrate/parser/gtfs_realtime.ex
@@ -155,6 +155,14 @@ defmodule Concentrate.Parser.GTFSRealtime do
     end
   end
 
+  defp decode_stop_updates(tu, %{stop_time_update: []}, options) do
+    if tu != [] and not valid_route_id?(options, TripUpdate.route_id(List.first(tu))) do
+      []
+    else
+      tu
+    end
+  end
+
   defp times_less_than_max?(_, _, :infinity), do: true
   defp times_less_than_max?(nil, nil, _), do: true
   defp times_less_than_max?(time, nil, max), do: time <= max

--- a/test/concentrate/encoder/gtfs_realtime_helpers_test.exs
+++ b/test/concentrate/encoder/gtfs_realtime_helpers_test.exs
@@ -53,9 +53,14 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpersTest do
       assert actual == expected
     end
 
-    test "trip updates without a vehicle or stop time are ignored" do
+    test "SCHEDULED trip updates without a vehicle or stop time are ignored" do
       tu = TripUpdate.new(trip_id: "trip")
       assert [] = group([tu])
+    end
+
+    test "CANCELED trip updates without a vehicle or stop time are kept" do
+      tu = TripUpdate.new(trip_id: "trip", schedule_relationship: :CANCELED)
+      assert [{^tu, [], []}] = group([tu])
     end
   end
 end

--- a/test/concentrate/encoder/trip_updates_enhanced_test.exs
+++ b/test/concentrate/encoder/trip_updates_enhanced_test.exs
@@ -51,6 +51,18 @@ defmodule Concentrate.Encoder.TripUpdatesEnhancedTest do
       assert decoded["entity"] == []
     end
 
+    test "trips with a non-SCHEDULED relationship can appear alone" do
+      initial = [
+        TripUpdate.new(trip_id: "1", schedule_relationship: :CANCELED)
+      ]
+
+      decoded = Jason.decode!(encode_groups(group(initial)))
+      trip_update = get_in(decoded, ["entity", Access.at(0), "trip_update"])
+      assert trip_update
+      assert trip_update["trip"]["schedule_relationship"] == "CANCELED"
+      refute "stop_time_update" in Map.keys(trip_update)
+    end
+
     test "trips/updates with schedule_relationship SCHEDULED don't have that field" do
       parsed = [
         TripUpdate.new(trip_id: "trip", schedule_relationship: :SCHEDULED),

--- a/test/concentrate/parser/gtfs_realtime_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_test.exs
@@ -183,6 +183,24 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
 
       assert [_, _, _] = decode_trip_update(update, %Options{max_time: 1})
     end
+
+    test "keeps the trip even without stop time updates" do
+      update = %{
+        trip: %{},
+        stop_time_update: []
+      }
+
+      assert [_] = decode_trip_update(update, %Options{})
+    end
+
+    test "ignores the trip when we're excluding the route even without stop time updates" do
+      update = %{
+        trip: %{route_id: "ignored"},
+        stop_time_update: []
+      }
+
+      assert [] = decode_trip_update(update, %Options{routes: {:ok, ["keeping"]}})
+    end
   end
 
   describe "decode_vehicle/2" do


### PR DESCRIPTION
Instead of ignoring them, we'll keep them but only if their status isn't
`SCHEDULED`.