### PR TITLE
MergeFilter: delay initial timeout

### DIFF
--- a/lib/concentrate/merge_filter.ex
+++ b/lib/concentrate/merge_filter.ex
@@ -15,6 +15,8 @@ defmodule Concentrate.MergeFilter do
   alias Concentrate.Encoder.GTFSRealtimeHelpers
 
   @start_link_opts [:name]
+  # allow sources some time to load
+  @initial_timeout 5_000
 
   defstruct timeout: 1_000,
             timer: nil,
@@ -41,8 +43,10 @@ defmodule Concentrate.MergeFilter do
         _ -> state
       end
 
+    initial_timeout = Keyword.get(opts, :initial_timeout, @initial_timeout)
     opts = Keyword.take(opts, [:subscribe_to, :dispatcher])
     opts = Keyword.put_new(opts, :dispatcher, GenStage.BroadcastDispatcher)
+    state = %{state | timer: Process.send_after(self(), :timeout, initial_timeout)}
     {:producer_consumer, state, opts}
   end
 

--- a/test/concentrate/merge_filter_test.exs
+++ b/test/concentrate/merge_filter_test.exs
@@ -28,7 +28,11 @@ defmodule Concentrate.MergeFilterTest do
   describe "handle_events/2" do
     test "schedules a timeout" do
       from = make_from()
-      {_, state, _} = init(timeout: 100)
+      {_, state, _} = init(initial_timeout: 100, timeout: 100)
+      assert state.timer
+      assert_receive :timeout, 500
+      {:noreply, _, state} = handle_info(:timeout, state)
+
       {_, state} = handle_subscribe(:producer, [], from, state)
       {:noreply, [], state} = handle_events([[], [], []], from, state)
       assert state.timer


### PR DESCRIPTION
This gives the sources some time to load their first set of data.

@cwh711 this was your idea (and a good one!) so you get to do the review :)