### PR TITLE
pass `excluded_routes` param to the parser

### DIFF
--- a/lib/concentrate/supervisor/pipeline.ex
+++ b/lib/concentrate/supervisor/pipeline.ex
@@ -31,7 +31,8 @@ defmodule Concentrate.Supervisor.Pipeline do
           case url do
             {url, opts} when is_binary(url) ->
               {url, opts,
-               {Concentrate.Parser.GTFSRealtime, Keyword.take(opts, ~w(routes max_future_time)a)}}
+               {Concentrate.Parser.GTFSRealtime,
+                Keyword.take(opts, ~w(routes excluded_routes max_future_time)a)}}
 
             url when is_binary(url) ->
               {url, [], Concentrate.Parser.GTFSRealtime}


### PR DESCRIPTION
Previously, we were filtering it out before it was passed to the parser.