### PR TITLE
don't remove the departure time except from the last stop

### DIFF
--- a/test/concentrate/group_filter/remove_unneeded_times_test.exs
+++ b/test/concentrate/group_filter/remove_unneeded_times_test.exs
@@ -45,6 +45,18 @@ defmodule Concentrate.GroupFilter.RemoveUnneededTimesTest do
       assert {_, [], [^expected]} = filter(group, @module)
     end
 
+    test "a departure_time is not removed if there are stops added afterward" do
+      # stop sequence 6 is skipped
+      stus =
+        for seq <- [5, 7] do
+          StopTimeUpdate.update(@stu, stop_sequence: seq)
+        end
+
+      group = {@tu, [], stus}
+      # no chanages
+      assert filter(group, @module) == group
+    end
+
     test "if the departure time is missing from the first stop, use the arrival time" do
       stu = StopTimeUpdate.update(@stu, stop_sequence: 1, departure_time: nil)
       group = {@tu, [], [stu]}


### PR DESCRIPTION
In some cases, the MBTA extends a train past where the schedule says the
train should go. In that case, we get additional StopTimeUpdates past the
original last stop. Previously, the RemoveUnneededTimes filter would remove
the departure time from the scheduled last stop, even though it's not
actually the last stop. 

This updates the filter to only remove the departure
time if the stop is also the last in the group.