### PR TITLE
better support for shuttles (via activities)

### DIFF
--- a/lib/concentrate/alert/informed_entity.ex
+++ b/lib/concentrate/alert/informed_entity.ex
@@ -11,7 +11,7 @@ defmodule Concentrate.Alert.InformedEntity do
     :route_id,
     :direction_id,
     :stop_id,
-    activities: []
+    activities: ["BOARD", "EXIT", "RIDE"]
   ])
 
   @spec match?(t, Keyword.t()) :: boolean

--- a/lib/concentrate/filter/alert/cancelled_trips.ex
+++ b/lib/concentrate/filter/alert/cancelled_trips.ex
@@ -44,14 +44,12 @@ defmodule Concentrate.Filter.Alert.CancelledTrips do
         {key, start, stop, @empty_value}
       end
 
-    unless inserts == [] do
-      TimeTable.update(@table, inserts)
+    TimeTable.update(@table, inserts)
 
-      _ =
-        Logger.info(fn ->
-          "#{__MODULE__} updated: records=#{length(inserts)}"
-        end)
-    end
+    _ =
+      Logger.info(fn ->
+        "#{__MODULE__} updated: records=#{length(inserts)}"
+      end)
 
     {:noreply, [], state}
   end

--- a/lib/concentrate/filter/alert/shuttles.ex
+++ b/lib/concentrate/filter/alert/shuttles.ex
@@ -64,14 +64,12 @@ defmodule Concentrate.Filter.Alert.Shuttles do
         {key, start, stop, value}
       end
 
-    unless inserts == [] do
-      TimeTable.update(@table, inserts)
+    TimeTable.update(@table, inserts)
 
-      _ =
-        Logger.info(fn ->
-          "#{__MODULE__} updated: records=#{length(inserts)}"
-        end)
-    end
+    _ =
+      Logger.info(fn ->
+        "#{__MODULE__} updated: records=#{length(inserts)}"
+      end)
 
     {:noreply, [], state}
   end

--- a/lib/concentrate/filter/alert/time_table.ex
+++ b/lib/concentrate/filter/alert/time_table.ex
@@ -16,6 +16,10 @@ defmodule Concentrate.Filter.Alert.TimeTable do
     :ets.insert(name, records)
   end
 
+  def update(name, []) do
+    :ets.delete_all_objects(name)
+  end
+
   @doc "Queries the table for matching keys that overlap the date/timestamp."
   def date_overlaps(name, key, date_or_timestamp) do
     {start, stop} = start_stop_times(date_or_timestamp)

--- a/lib/concentrate/group_filter/shuttle.ex
+++ b/lib/concentrate/group_filter/shuttle.ex
@@ -42,7 +42,7 @@ defmodule Concentrate.GroupFilter.Shuttle do
     time = StopTimeUpdate.time(stu)
     stop_id = StopTimeUpdate.stop_id(stu)
 
-    if is_integer(time) and module.stop_shuttling_on_route?(route_id, stop_id, time) do
+    if is_integer(time) and module.stop_shuttling_on_route(route_id, stop_id, time) == :through do
       {[StopTimeUpdate.skip(stu)], true}
     else
       {[stu], false}

--- a/lib/concentrate/group_filter/shuttle.ex
+++ b/lib/concentrate/group_filter/shuttle.ex
@@ -42,8 +42,20 @@ defmodule Concentrate.GroupFilter.Shuttle do
     time = StopTimeUpdate.time(stu)
     stop_id = StopTimeUpdate.stop_id(stu)
 
-    if is_integer(time) and module.stop_shuttling_on_route(route_id, stop_id, time) == :through do
-      {[StopTimeUpdate.skip(stu)], true}
+    if is_integer(time) do
+      case module.stop_shuttling_on_route(route_id, stop_id, time) do
+        nil ->
+          {[stu], false}
+
+        :through ->
+          {[StopTimeUpdate.skip(stu)], true}
+
+        :start ->
+          {[StopTimeUpdate.update_departure_time(stu, nil)], true}
+
+        :stop ->
+          {[StopTimeUpdate.update_arrival_time(stu, nil)], false}
+      end
     else
       {[stu], false}
     end

--- a/test/concentrate/filter/alert/cancelled_trips_test.exs
+++ b/test/concentrate/filter/alert/cancelled_trips_test.exs
@@ -76,6 +76,26 @@ defmodule Concentrate.Filter.Alert.CancelledTripsTest do
         assert trip_cancelled?("trip", @one_day * i)
       end
     end
+
+    test "clearing the alert no longer cancels the trip" do
+      alert =
+        Alert.new(
+          effect: :NO_SERVICE,
+          active_period: [
+            {5, 10}
+          ],
+          informed_entity: [
+            InformedEntity.new(trip_id: "trip_with_stop", stop_id: "stop"),
+            InformedEntity.new(trip_id: "trip_with_route", route_id: "route")
+          ]
+        )
+
+      handle_events([[alert]], :from, :state)
+      handle_events([[]], :from, :state)
+
+      refute trip_cancelled?("trip_with_route", 5)
+      refute trip_cancelled?("trip_with_route", {1970, 1, 1})
+    end
   end
 
   describe "route_cancelled?/1" do

--- a/test/concentrate/filter/alert/shuttles_test.exs
+++ b/test/concentrate/filter/alert/shuttles_test.exs
@@ -49,6 +49,24 @@ defmodule Concentrate.Filter.Alert.ShuttlesTest do
       assert trip_shuttling?("ferry_trip", "ferry", 1, 5)
       refute trip_shuttling?("other_trip", "ferry", 1, 5)
     end
+
+    test "clearing an alert stops shuttling the trips" do
+      alert =
+        Alert.new(
+          effect: :DETOUR,
+          active_period: [
+            {5, 10}
+          ],
+          informed_entity: [
+            InformedEntity.new(route_type: 1, route_id: "route", stop_id: "stop_id")
+          ]
+        )
+
+      handle_events([[alert]], :from, :state)
+      handle_events([[]], :from, :state)
+
+      refute trip_shuttling?("trip", "route", 0, 5)
+    end
   end
 
   describe "stop_shuttling_on_route?/1" do

--- a/test/concentrate/filter/alert/shuttles_test.exs
+++ b/test/concentrate/filter/alert/shuttles_test.exs
@@ -54,7 +54,7 @@ defmodule Concentrate.Filter.Alert.ShuttlesTest do
   describe "stop_shuttling_on_route?/1" do
     setup :supervised
 
-    test "returns a boolean indicating whether the route is shuttling a particular stop" do
+    test "returns a atom indicating whether the route is shuttling a particular stop" do
       alert =
         Alert.new(
           effect: :DETOUR,
@@ -63,15 +63,29 @@ defmodule Concentrate.Filter.Alert.ShuttlesTest do
             {15, 20}
           ],
           informed_entity: [
-            InformedEntity.new(route_type: 2, route_id: "route", stop_id: "stop")
+            InformedEntity.new(route_type: 2, route_id: "route", stop_id: "through"),
+            InformedEntity.new(
+              route_type: 2,
+              route_id: "route",
+              stop_id: "start",
+              activities: ["BOARD", "RIDE"]
+            ),
+            InformedEntity.new(
+              route_type: 2,
+              route_id: "route",
+              stop_id: "stop",
+              activities: ["RIDE", "EXIT"]
+            )
           ]
         )
 
       handle_events([[alert]], :from, :state)
 
-      assert stop_shuttling_on_route?("route", "stop", 5)
-      refute stop_shuttling_on_route?("route", "stop", 21)
-      assert stop_shuttling_on_route?("route", "stop", {1970, 1, 1})
+      assert stop_shuttling_on_route("route", "through", 5) == :through
+      assert stop_shuttling_on_route("route", "through", 21) == nil
+      assert stop_shuttling_on_route("route", "through", {1970, 1, 1}) == :through
+      assert stop_shuttling_on_route("route", "start", 5) == :start
+      assert stop_shuttling_on_route("route", "stop", 5) == :stop
     end
   end
 
@@ -80,8 +94,8 @@ defmodule Concentrate.Filter.Alert.ShuttlesTest do
       refute trip_shuttling?("trip", "route", 0, 0)
     end
 
-    test "stop_shuttling_on_route?/3 returns false" do
-      refute stop_shuttling_on_route?("route", "stop", 0)
+    test "stop_shuttling_on_route/3 returns nil" do
+      assert stop_shuttling_on_route("route", "stop", 0) == nil
     end
   end
 

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -45,7 +45,6 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
                     },
                     "stop_id": "Worcester",
                     "activities": [
-                      "BOARD",
                       "EXIT",
                       "RIDE"
                     ]
@@ -62,7 +61,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
       assert InformedEntity.direction_id(entity) == 1
       assert InformedEntity.trip_id(entity) == "CR-Weekday-Fall-17-516"
       assert InformedEntity.stop_id(entity) == "Worcester"
-      assert InformedEntity.activities(entity) == ~w(BOARD EXIT RIDE)
+      assert InformedEntity.activities(entity) == ~w(EXIT RIDE)
     end
 
     test "alerts can decoded the old-format feed" do

--- a/test/support/filter/fakes.ex
+++ b/test/support/filter/fakes.ex
@@ -79,8 +79,10 @@ defmodule Concentrate.Filter.FakeShuttles do
   def trip_shuttling?("trip", "single_direction", 0, {1970, 1, 1}), do: true
   def trip_shuttling?(_trip_id, _route_id, _direction_id, {_, _, _}), do: false
 
-  def stop_shuttling_on_route?("route", "shuttle_1", 8), do: true
-  def stop_shuttling_on_route?("route", "shuttle_2", 8), do: true
-  def stop_shuttling_on_route?("single_direction", "shuttle_1", 8), do: true
-  def stop_shuttling_on_route?(_, _, dt) when is_integer(dt), do: false
+  def stop_shuttling_on_route("route", "shuttle_1", 8), do: :through
+  def stop_shuttling_on_route("route", "shuttle_2", 8), do: :through
+  def stop_shuttling_on_route("route", "shuttle_start", 8), do: :start
+  def stop_shuttling_on_route("route", "shuttle_stop", 8), do: :stop
+  def stop_shuttling_on_route("single_direction", "shuttle_1", 8), do: :through
+  def stop_shuttling_on_route(_, _, dt) when is_integer(dt), do: nil
 end


### PR DESCRIPTION
In the Enhanced JSON feed, alert InformedEntities have a list of activities the entity is related to. For shuttles, we can use this keep the last arrival for a train to the stop which is being shuttled.

- InformedEntities with activities BOARD and EXIT: skip the stop since riders can neither board or exit at that stop
- BOARD but not EXIT - only affects boarding, so remove the departure time
- EXIT but not BOARD - prevents passengers from being on the train before this stop, so remove the arrival time