### PR TITLE
support merging different stop IDs

### DIFF
--- a/lib/concentrate/filter/gtfs/stops.ex
+++ b/lib/concentrate/filter/gtfs/stops.ex
@@ -1,0 +1,60 @@
+defmodule Concentrate.Filter.GTFS.Stops do
+  @moduledoc """
+  Server which maintains a list of stop id -> parent station ID.
+  """
+  use GenStage
+  require Logger
+  import :binary, only: [copy: 1]
+  @table __MODULE__
+
+  def start_link(opts) do
+    GenStage.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc "Returns the parent station ID for a stop"
+  def parent_station_id(stop_id) when is_binary(stop_id) do
+    case :ets.match(@table, {stop_id, :"$1"}) do
+      [] -> stop_id
+      [[parent_station_id]] -> parent_station_id
+    end
+  rescue
+    ArgumentError -> stop_id
+  end
+
+  @doc !"Test hook to add a child/parent mapping"
+  def _insert_mapping(child_id, parent_id) when is_binary(child_id) and is_binary(parent_id) do
+    true = :ets.insert(@table, {child_id, parent_id})
+    :ok
+  end
+
+  def init(opts) do
+    :ets.new(@table, [:named_table, :public, :duplicate_bag])
+    {:consumer, %{}, opts}
+  end
+
+  def handle_events(events, _from, state) do
+    inserts =
+      for event <- events,
+          {"stops.txt", trip_body} <- event,
+          lines = String.split(trip_body, "\n"),
+          {:ok, row} <- CSV.decode(lines, headers: true),
+          parent_station_id = row["parent_station"],
+          parent_station_id != "" do
+        {copy(row["stop_id"]), copy(parent_station_id)}
+      end
+
+    _ =
+      if inserts == [] do
+        :ok
+      else
+        true = :ets.delete_all_objects(@table)
+        true = :ets.insert(@table, inserts)
+
+        Logger.info(fn ->
+          "#{__MODULE__}: updated with #{length(inserts)} records"
+        end)
+      end
+
+    {:noreply, [], state, :hibernate}
+  end
+end

--- a/lib/concentrate/filter/gtfs/supervisor.ex
+++ b/lib/concentrate/filter/gtfs/supervisor.ex
@@ -22,6 +22,7 @@ defmodule Concentrate.Filter.GTFS.Supervisor do
             }
           },
           {Concentrate.Filter.GTFS.Trips, subscribe_to: [:gtfs_producer]},
+          {Concentrate.Filter.GTFS.Stops, subscribe_to: [:gtfs_producer]},
           {Concentrate.Filter.GTFS.PickupDropOff, subscribe_to: [:gtfs_producer]}
         ],
         strategy: :rest_for_one

--- a/lib/concentrate/filter/gtfs/unzip.ex
+++ b/lib/concentrate/filter/gtfs/unzip.ex
@@ -3,7 +3,7 @@ defmodule Concentrate.Filter.GTFS.Unzip do
   Unzips the GTFS file into constituent files.
   """
   @behaviour Concentrate.Parser
-  @file_list ['trips.txt', 'stop_times.txt']
+  @file_list ['trips.txt', 'stop_times.txt', 'stops.txt']
 
   def parse(binary, _opts) do
     {:ok, files} = :zip.unzip(binary, [:memory, file_list: @file_list])

--- a/lib/concentrate/stop_time_update.ex
+++ b/lib/concentrate/stop_time_update.ex
@@ -3,6 +3,7 @@ defmodule Concentrate.StopTimeUpdate do
   Structure for representing an update to a StopTime (e.g. a predicted arrival or departure)
   """
   import Concentrate.StructHelpers
+  alias Concentrate.Filter.GTFS.Stops
 
   defstruct_accessors([
     :trip_id,
@@ -35,7 +36,12 @@ defmodule Concentrate.StopTimeUpdate do
 
   defimpl Concentrate.Mergeable do
     def key(%{trip_id: trip_id, stop_id: stop_id, stop_sequence: stop_sequence}) do
-      {trip_id, stop_id, stop_sequence}
+      parent_station_id =
+        if stop_id do
+          Stops.parent_station_id(stop_id)
+        end
+
+      {trip_id, parent_station_id, stop_sequence}
     end
 
     def merge(first, second) do
@@ -51,6 +57,7 @@ defmodule Concentrate.StopTimeUpdate do
             else
               first.schedule_relationship
             end,
+          stop_id: max(first.stop_id, second.stop_id),
           platform_id: first.platform_id || second.platform_id
       }
     end

--- a/test/concentrate/filter/gtfs/stops_test.exs
+++ b/test/concentrate/filter/gtfs/stops_test.exs
@@ -1,0 +1,41 @@
+defmodule Concentrate.Filter.GTFS.StopsTest do
+  @moduledoc false
+  use ExUnit.Case
+  import Concentrate.Filter.GTFS.Stops
+
+  @body """
+  "stop_id","stop_code","stop_name","stop_desc","platform_code","platform_name","stop_lat","stop_lon","stop_address","zone_id","stop_url","level_id","location_type","parent_station","wheelchair_boarding"
+  "South Station","","South Station","South Station - Commuter Rail","","Commuter Rail",42.35176309,-71.05479665,"","","","level_0_cr_platform",0,"place-sstat",1
+  "place-sstat","","South Station","","","",42.352271,-71.055242,"","","","",1,"",1
+  """
+
+  defp supervised(_) do
+    start_supervised!(Concentrate.Filter.GTFS.Stops)
+    event = [{"stops.txt", @body}]
+    # relies on being able to update the table from a different process
+    handle_events([event], :ignored, :ignored)
+    :ok
+  end
+
+  describe "parent_station_id/1" do
+    setup :supervised
+
+    test "returns the stop ID if it doesn't have a parent" do
+      assert parent_station_id("5") == "5"
+    end
+
+    test "returns the parent ID for the parent itself" do
+      assert parent_station_id("place-sstat") == "place-sstat"
+    end
+
+    test "returns the parent ID for a child" do
+      assert parent_station_id("South Station") == "place-sstat"
+    end
+  end
+
+  describe "missing ETS table" do
+    test "parent_station_id/1 returns the given stop ID" do
+      assert parent_station_id("missing") == "missing"
+    end
+  end
+end

--- a/test/concentrate/stop_time_update_test.exs
+++ b/test/concentrate/stop_time_update_test.exs
@@ -1,10 +1,19 @@
 defmodule Concentrate.StopTimeUpdateTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   import Concentrate.StopTimeUpdate
   alias Concentrate.Mergeable
 
   describe "Concentrate.Mergeable" do
+    test "key/1 uses the parent station ID" do
+      start_supervised!(Concentrate.Filter.GTFS.Stops)
+      Concentrate.Filter.GTFS.Stops._insert_mapping("child_id", "parent_id")
+
+      assert Mergeable.key(new(stop_id: "child_id")) == {nil, "parent_id", nil}
+      assert Mergeable.key(new(stop_id: "other")) == {nil, "other", nil}
+      assert Mergeable.key(new(stop_id: nil)) == {nil, nil, nil}
+    end
+
     test "merge/2 takes non-nil values, earliest arrival, latest departure" do
       first =
         new(
@@ -20,7 +29,7 @@ defmodule Concentrate.StopTimeUpdateTest do
       second =
         new(
           trip_id: "trip",
-          stop_id: "stop",
+          stop_id: "stop-01",
           stop_sequence: 1,
           arrival_time: 1,
           departure_time: 4,
@@ -31,7 +40,7 @@ defmodule Concentrate.StopTimeUpdateTest do
       expected =
         new(
           trip_id: "trip",
-          stop_id: "stop",
+          stop_id: "stop-01",
           stop_sequence: 1,
           arrival_time: 1,
           departure_time: 4,


### PR DESCRIPTION
In the future, we'll be uising different stop IDs for each track/platform:
they'll share a parent station ID. This updates the merging algorithm for
`StopTimeUpdate` to combine them, based on the parent station ID.