### PR TITLE
filter to match VehiclePosition stop_id to StopTimeUpdate

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,6 +33,7 @@ config :concentrate,
     Concentrate.GroupFilter.SkippedDepartures,
     Concentrate.GroupFilter.CancelledTrip,
     Concentrate.GroupFilter.VehicleAtSkippedStop,
+    Concentrate.GroupFilter.VehicleStopMatch,
     Concentrate.GroupFilter.SkippedStopOnAddedTrip
   ],
   reporters: [

--- a/lib/concentrate/group_filter/vehicle_stop_match.ex
+++ b/lib/concentrate/group_filter/vehicle_stop_match.ex
@@ -1,0 +1,46 @@
+defmodule Concentrate.GroupFilter.VehicleStopMatch do
+  @moduledoc """
+  Updates a VehiclePosition's `stop_id` to match the StopTimeUpdate.
+
+  When using the `stop_id` of the StopTimeUpdate to assign the trip to a
+  track, it may become out of sync with the stop ID the vehicle is at. This
+  filter updates the stop_id for the VehiclePosition to be the same as that
+  of the StopTimeUpdate with the same stop sequence (if they share a parent).
+  """
+  @behaviour Concentrate.GroupFilter
+  alias Concentrate.{StopTimeUpdate, VehiclePosition}
+  alias Concentrate.Filter.GTFS.Stops
+
+  @impl Concentrate.GroupFilter
+  def filter({tu, vps, stus}) do
+    vps =
+      for vp <- vps do
+        match_stop_id(vp, stus)
+      end
+
+    {tu, vps, stus}
+  end
+
+  defp match_stop_id(vp, stus) do
+    vp_stop_sequence = VehiclePosition.stop_sequence(vp)
+    update = Enum.find(stus, &(StopTimeUpdate.stop_sequence(&1) == vp_stop_sequence))
+
+    match_stop_id_to_update(vp, update)
+  end
+
+  defp match_stop_id_to_update(vp, %StopTimeUpdate{} = stu) do
+    vp_stop_id = VehiclePosition.stop_id(vp)
+    stu_stop_id = StopTimeUpdate.stop_id(stu)
+
+    if vp_stop_id != stu_stop_id and
+         Stops.parent_station_id(vp_stop_id) == Stops.parent_station_id(stu_stop_id) do
+      VehiclePosition.update_stop_id(vp, stu_stop_id)
+    else
+      vp
+    end
+  end
+
+  defp match_stop_id_to_update(vp, nil) do
+    vp
+  end
+end

--- a/test/concentrate/group_filter/vehicle_stop_match_test.exs
+++ b/test/concentrate/group_filter/vehicle_stop_match_test.exs
@@ -1,0 +1,51 @@
+defmodule Concentrate.GroupFilter.VehicleStopMatchTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  import Concentrate.GroupFilter.VehicleStopMatch
+  alias Concentrate.{StopTimeUpdate, VehiclePosition}
+  alias Concentrate.Filter.GTFS.Stops
+
+  describe "filter/1" do
+    test "updates the VehiclePosition stop_id to match the StopTimeUpdate" do
+      start_supervised!(Stops)
+      Stops._insert_mapping("child1", "parent")
+      Stops._insert_mapping("child2", "parent")
+
+      vp = VehiclePosition.new(stop_id: "child1", stop_sequence: 2, latitude: 1, longitude: 2)
+
+      stus = [
+        StopTimeUpdate.new(stop_id: "first", stop_sequence: 1),
+        StopTimeUpdate.new(stop_id: "child2", stop_sequence: 2)
+      ]
+
+      {_, [new_vp], _} = filter({nil, [vp], stus})
+
+      assert VehiclePosition.stop_id(new_vp) == "child2"
+    end
+
+    test "does not update if the parent station's don't match" do
+      vp = VehiclePosition.new(stop_id: "child1", stop_sequence: 1, latitude: 1, longitude: 2)
+
+      stus = [
+        StopTimeUpdate.new(stop_id: "other", stop_sequence: 1)
+      ]
+
+      assert {_, [^vp], _} = filter({nil, [vp], stus})
+    end
+
+    test "does nothing if the stop IDs already match" do
+      vp = VehiclePosition.new(stop_id: "stop", stop_sequence: 1, latitude: 1, longitude: 2)
+
+      stus = [
+        StopTimeUpdate.new(stop_id: "stop", stop_sequence: 1)
+      ]
+
+      assert {_, [^vp], _} = filter({nil, [vp], stus})
+    end
+
+    test "does nothing if we can't find a matching stop_sequence" do
+      vp = VehiclePosition.new(stop_id: "child1", stop_sequence: 1, latitude: 1, longitude: 2)
+      assert {_, [^vp], _} = filter({nil, [vp], []})
+    end
+  end
+end


### PR DESCRIPTION
When we assign the trip to a track, we want the vehicle to also use that stop ID.

Follow-on work to #53.