### PR TITLE
better handling of shuttles at the start of trips

### DIFF
--- a/lib/concentrate/group_filter/shuttle.ex
+++ b/lib/concentrate/group_filter/shuttle.ex
@@ -28,36 +28,47 @@ defmodule Concentrate.GroupFilter.Shuttle do
   def filter(other, _module), do: other
 
   defp shuttle_updates(route_id, stus, module) do
-    {stus, _} = Enum.flat_map_reduce(stus, false, &shuttle_stop(route_id, module, &1, &2))
+    {stus, _} =
+      Enum.flat_map_reduce(stus, {false, false}, &shuttle_stop(route_id, module, &1, &2))
+
     stus
   end
 
-  defp shuttle_stop(route_id, shuttle_module, stop_time_updates, has_shuttled?)
+  defp shuttle_stop(route_id, shuttle_module, stop_time_updates, state)
 
-  defp shuttle_stop(_route_id, _module, stu, true) do
-    {[StopTimeUpdate.skip(stu)], true}
+  defp shuttle_stop(_route_id, _module, stu, {true, true} = state) do
+    {[StopTimeUpdate.skip(stu)], state}
   end
 
-  defp shuttle_stop(route_id, module, stu, false) do
+  defp shuttle_stop(route_id, module, stu, {has_started?, has_shuttled?}) do
     time = StopTimeUpdate.time(stu)
     stop_id = StopTimeUpdate.stop_id(stu)
 
     if is_integer(time) do
       case module.stop_shuttling_on_route(route_id, stop_id, time) do
         nil ->
-          {[stu], false}
+          drop_arrival_time_if_not_started(stu, has_started?, has_shuttled?)
 
         :through ->
-          {[StopTimeUpdate.skip(stu)], true}
+          {[StopTimeUpdate.skip(stu)], {has_started?, has_shuttled? || has_started?}}
 
         :start ->
-          {[StopTimeUpdate.update_departure_time(stu, nil)], true}
+          {[StopTimeUpdate.update_departure_time(stu, nil)],
+           {has_started?, has_shuttled? || has_started?}}
 
         :stop ->
-          {[StopTimeUpdate.update_arrival_time(stu, nil)], false}
+          {[StopTimeUpdate.update_arrival_time(stu, nil)], {true, has_shuttled?}}
       end
     else
-      {[stu], false}
+      drop_arrival_time_if_not_started(stu, has_started?, has_shuttled?)
     end
+  end
+
+  defp drop_arrival_time_if_not_started(stu, false, has_shuttled?) do
+    {[StopTimeUpdate.update_arrival_time(stu, nil)], {true, has_shuttled?}}
+  end
+
+  defp drop_arrival_time_if_not_started(stu, true, has_shuttled?) do
+    {[stu], {true, has_shuttled?}}
   end
 end


### PR DESCRIPTION
Previously, the behavior for shuttles at the start of trips was to cancel the
entire trip. However, this isn't the desired behavior: trips skipped at the
beginning are generally running the second part of the trip.

The new behavior is to only skip the stop times at the beginning. If boarding
is available at the last stop in the shuttle, then that stop will not be
skipped but instead only lose its `arrival_time`.