### PR TITLE
pin build to Elixir 1.6.5/Erlang 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,23 @@
-FROM elixir:alpine as builder
+FROM erlang:20-alpine AS builder
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.6.5" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
+	&& ELIXIR_DOWNLOAD_SHA256="ba2afd91ce65ec94d460a94752fa2560391b349d0fd598847f496ee041a44b80" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		unzip \
+	' \
+	&& apk add --no-cache --virtual .build-deps $buildDeps \
+	&& curl -fSL -o elixir-precompiled.zip $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-precompiled.zip" | sha256sum -c - \
+	&& unzip -d /usr/local elixir-precompiled.zip \
+	&& rm elixir-precompiled.zip \
+    && apk del .build-deps
 
 WORKDIR /root
 


### PR DESCRIPTION
Erlang 21 has an issue with `ehmon`, a library we use for logging system information. By going back to Elixir 1.6.5 and Erlang 20, we avoid the issue for now.

I deployed this to dev, and you can see the start of the errors when `master` was deployed, followed by the end of the errors when this branch is deployed, [here](https://mbta.splunkcloud.com/en-US/app/search/search?earliest=1530528022&latest=1530535222&q=search%20index%3Dconcentrate-dev%20(%22%5Berror%5D%22%20OR%20%22%5Bwarn%5D%22)%20%7C%20eval%20error%3Dif(like(_raw%2C%20%22%25%20%5Berror%5D%20%25%22)%2C%201%2C%200)%20%7C%20timechart%20sum(error)%20as%20errors&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=visualizations&display.page.search.tab=visualizations&display.visualizations.charting.chart=column&sid=1530531634.5618893).