### PR TITLE
ensure that trip_update/vehicle/alert is a map

### DIFF
--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -30,15 +30,15 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
     end
   end
 
-  defp decode_feed_entity(%{"trip_update" => trip_update}) do
+  defp decode_feed_entity(%{"trip_update" => %{} = trip_update}) do
     decode_trip_update(trip_update)
   end
 
-  defp decode_feed_entity(%{"vehicle" => vehicle}) do
+  defp decode_feed_entity(%{"vehicle" => %{} = vehicle}) do
     decode_vehicle(vehicle)
   end
 
-  defp decode_feed_entity(%{"id" => id, "alert" => alert}) do
+  defp decode_feed_entity(%{"id" => id, "alert" => %{} = alert}) do
     [
       Alert.new(
         id: id,

--- a/test/fixtures/VehiclePositions_enhanced.json
+++ b/test/fixtures/VehiclePositions_enhanced.json
@@ -6,6 +6,7 @@
   },
   "entity": [
     {
+      "trip_update": null,
       "vehicle": {
         "vehicle": {
           "id": "0806"


### PR DESCRIPTION
Previously, if the key was present but `null`, we'd crash during parsing.