### PR TITLE
convert binary vehicle status to an atom

### DIFF
--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -98,7 +98,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
             bearing: Map.get(position, "bearing"),
             speed: Map.get(position, "speed"),
             odometer: Map.get(position, "odometer"),
-            status: Map.get(vp, "current_status"),
+            status: vehicle_status(Map.get(vp, "current_status")),
             stop_sequence: Map.get(vp, "current_stop_sequence"),
             last_updated: Map.get(vp, "timestamp")
           )
@@ -150,6 +150,13 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
 
   for relationship <- ~w(SCHEDULED ADDED UNSCHEDULED CANCELED SKIPPED NO_DATA)a do
     defp schedule_relationship(unquote(Atom.to_string(relationship))), do: unquote(relationship)
+  end
+
+  # default
+  defp vehicle_status(nil), do: :IN_TRANSIT_TO
+
+  for status <- ~w(INCOMING_AT STOPPED_AT IN_TRANSIT_TO)a do
+    defp vehicle_status(unquote(Atom.to_string(status))), do: unquote(status)
   end
 
   for effect <- ~w(

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -158,5 +158,61 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
     test "returns nothing if there's an empty map" do
       assert decode_vehicle(%{}) == []
     end
+
+    test "decodes a VehiclePosition JSON map" do
+      map = %{
+        "congestion_level" => nil,
+        "current_status" => "STOPPED_AT",
+        "current_stop_sequence" => 670,
+        "occupancy_status" => nil,
+        "position" => %{
+          "bearing" => 135,
+          "latitude" => 42.32951,
+          "longitude" => -71.11109,
+          "odometer" => nil,
+          "speed" => nil
+        },
+        "stop_id" => "70257",
+        "timestamp" => 1_534_340_406,
+        "trip" => %{
+          "direction_id" => 0,
+          "route_id" => "Green-E",
+          "schedule_relationship" => "SCHEDULED",
+          "start_date" => "20180815",
+          "start_time" => nil,
+          "trip_id" => "37165437-X"
+        },
+        "vehicle" => %{
+          "id" => "G-10098",
+          "label" => "3823-3605",
+          "license_plate" => nil
+        }
+      }
+
+      assert [tu, vp] = decode_vehicle(map)
+
+      assert tu ==
+               TripUpdate.new(
+                 trip_id: "37165437-X",
+                 route_id: "Green-E",
+                 direction_id: 0,
+                 start_date: {2018, 8, 15},
+                 schedule_relationship: :SCHEDULED
+               )
+
+      assert vp ==
+               VehiclePosition.new(
+                 id: "G-10098",
+                 label: "3823-3605",
+                 latitude: 42.32951,
+                 longitude: -71.11109,
+                 bearing: 135,
+                 stop_id: "70257",
+                 trip_id: "37165437-X",
+                 stop_sequence: 670,
+                 status: :STOPPED_AT,
+                 last_updated: 1_534_340_406
+               )
+    end
   end
 end


### PR DESCRIPTION
Previously we left it as a binary, which then failed to encode as a PB file later.

Changes are mostly to add better testing for decoding a JSON VehiclePositions file into our internal structures.