### PR TITLE
pass uncertainty values through the pipeline

### DIFF
--- a/lib/concentrate/encoder/gtfs_realtime_helpers.ex
+++ b/lib/concentrate/encoder/gtfs_realtime_helpers.ex
@@ -108,12 +108,24 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
       %{time: 123}
       iex> stop_time_event(nil)
       nil
+      iex> stop_time_event(123, 300)
+      %{time: 123, uncertainty: 300}
   """
-  def stop_time_event(nil) do
+  def stop_time_event(time, uncertainty \\ nil)
+
+  def stop_time_event(nil, _) do
     nil
   end
 
-  def stop_time_event(unix_timestamp) do
+  def stop_time_event(unix_timestamp, uncertainty)
+      when is_integer(uncertainty) and uncertainty > 0 do
+    %{
+      time: unix_timestamp,
+      uncertainty: uncertainty
+    }
+  end
+
+  def stop_time_event(unix_timestamp, _) do
     %{
       time: unix_timestamp
     }

--- a/lib/concentrate/encoder/trip_updates.ex
+++ b/lib/concentrate/encoder/trip_updates.ex
@@ -20,8 +20,10 @@ defmodule Concentrate.Encoder.TripUpdates do
     drop_nil_values(%{
       stop_id: StopTimeUpdate.stop_id(update),
       stop_sequence: StopTimeUpdate.stop_sequence(update),
-      arrival: stop_time_event(StopTimeUpdate.arrival_time(update)),
-      departure: stop_time_event(StopTimeUpdate.departure_time(update)),
+      arrival:
+        stop_time_event(StopTimeUpdate.arrival_time(update), StopTimeUpdate.uncertainty(update)),
+      departure:
+        stop_time_event(StopTimeUpdate.departure_time(update), StopTimeUpdate.uncertainty(update)),
       schedule_relationship: schedule_relationship(StopTimeUpdate.schedule_relationship(update))
     })
   end

--- a/lib/concentrate/encoder/trip_updates_enhanced.ex
+++ b/lib/concentrate/encoder/trip_updates_enhanced.ex
@@ -20,8 +20,10 @@ defmodule Concentrate.Encoder.TripUpdatesEnhanced do
     drop_nil_values(%{
       stop_id: StopTimeUpdate.stop_id(update),
       stop_sequence: StopTimeUpdate.stop_sequence(update),
-      arrival: stop_time_event(StopTimeUpdate.arrival_time(update)),
-      departure: stop_time_event(StopTimeUpdate.departure_time(update)),
+      arrival:
+        stop_time_event(StopTimeUpdate.arrival_time(update), StopTimeUpdate.uncertainty(update)),
+      departure:
+        stop_time_event(StopTimeUpdate.departure_time(update), StopTimeUpdate.uncertainty(update)),
       schedule_relationship: schedule_relationship(StopTimeUpdate.schedule_relationship(update)),
       boarding_status: StopTimeUpdate.status(update),
       platform_id: StopTimeUpdate.platform_id(update)

--- a/lib/concentrate/stop_time_update.ex
+++ b/lib/concentrate/stop_time_update.ex
@@ -14,6 +14,7 @@ defmodule Concentrate.StopTimeUpdate do
     :status,
     :track,
     :platform_id,
+    :uncertainty,
     schedule_relationship: :SCHEDULED
   ])
 
@@ -58,7 +59,8 @@ defmodule Concentrate.StopTimeUpdate do
               first.schedule_relationship
             end,
           stop_id: max(first.stop_id, second.stop_id),
-          platform_id: first.platform_id || second.platform_id
+          platform_id: first.platform_id || second.platform_id,
+          uncertainty: first.uncertainty || second.uncertainty
       }
     end
 

--- a/semaphore/deploy.sh
+++ b/semaphore/deploy.sh
@@ -27,7 +27,7 @@ function task_count_eq {
 }
 
 function exit_if_too_many_checks {
-  if [[ $checks -ge 12 ]]; then
+  if [[ $checks -ge 60 ]]; then
     exit 1
   fi
   sleep 5

--- a/test/concentrate/parser/gtfs_realtime_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_test.exs
@@ -91,6 +91,21 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
       refute StopTimeUpdate.departure_time(stop_update)
     end
 
+    test "can handle uncertainty" do
+      update = %{
+        trip: %{},
+        stop_time_update: [
+          %{
+            arrival: nil,
+            departure: %{time: 1, uncertainty: 300}
+          }
+        ]
+      }
+
+      [_tu, stop_update] = decode_trip_update(update, %Options{})
+      assert StopTimeUpdate.uncertainty(stop_update) == 300
+    end
+
     test "can handle missing schedule_relationship" do
       update = %{
         trip: %{},

--- a/test/concentrate/stop_time_update_test.exs
+++ b/test/concentrate/stop_time_update_test.exs
@@ -34,7 +34,8 @@ defmodule Concentrate.StopTimeUpdateTest do
           arrival_time: 1,
           departure_time: 4,
           track: "track",
-          schedule_relationship: :SKIPPED
+          schedule_relationship: :SKIPPED,
+          uncertainty: 300
         )
 
       expected =
@@ -47,7 +48,8 @@ defmodule Concentrate.StopTimeUpdateTest do
           status: "status",
           track: "track",
           schedule_relationship: :SKIPPED,
-          platform_id: "platform"
+          platform_id: "platform",
+          uncertainty: 300
         )
 
       assert Mergeable.merge(first, second) == expected


### PR DESCRIPTION
It turns out that Swiftly uses an `uncertainty` value of 300 for predictions which are based on the schedule, and Transit also knows how to handle that value.