### PR TITLE
allow configuring headers for sources

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir v1.6.4-otp-20
+elixir v1.6.6-otp-20
 erlang 20.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,4 @@
-FROM erlang:20-alpine AS builder
-
-# elixir expects utf8.
-ENV ELIXIR_VERSION="v1.6.5" \
-	LANG=C.UTF-8
-
-RUN set -xe \
-	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="ba2afd91ce65ec94d460a94752fa2560391b349d0fd598847f496ee041a44b80" \
-	&& buildDeps=' \
-		ca-certificates \
-		curl \
-		unzip \
-	' \
-	&& apk add --no-cache --virtual .build-deps $buildDeps \
-	&& curl -fSL -o elixir-precompiled.zip $ELIXIR_DOWNLOAD_URL \
-	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-precompiled.zip" | sha256sum -c - \
-	&& unzip -d /usr/local elixir-precompiled.zip \
-	&& rm elixir-precompiled.zip \
-    && apk del .build-deps
+FROM elixir:1.6-alpine AS builder
 
 WORKDIR /root
 

--- a/lib/concentrate/parser/gtfs_realtime.ex
+++ b/lib/concentrate/parser/gtfs_realtime.ex
@@ -141,8 +141,8 @@ defmodule Concentrate.Parser.GTFSRealtime do
       true ->
         stop_updates =
           for stu <- updates do
-            {arrival_time, arrival_uncertainty} = time_from_event(Map.get(update, :arrival))
-            {departure_time, departure_uncertainty} = time_from_event(Map.get(update, :departure))
+            {arrival_time, arrival_uncertainty} = time_from_event(Map.get(stu, :arrival))
+            {departure_time, departure_uncertainty} = time_from_event(Map.get(stu, :departure))
 
             StopTimeUpdate.new(
               trip_id: Map.get(trip_update.trip, :trip_id),

--- a/test/concentrate/parser/gtfs_realtime_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_test.exs
@@ -98,12 +98,21 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
           %{
             arrival: nil,
             departure: %{time: 1, uncertainty: 300}
+          },
+          %{
+            arrival: %{uncertainty: 4, time: 2},
+            departure: %{time: 3}
           }
         ]
       }
 
-      [_tu, stop_update] = decode_trip_update(update, %Options{})
-      assert StopTimeUpdate.uncertainty(stop_update) == 300
+      [_tu, stop_update_1, stop_update_2] = decode_trip_update(update, %Options{})
+      assert StopTimeUpdate.arrival_time(stop_update_1) == nil
+      assert StopTimeUpdate.departure_time(stop_update_1) == 1
+      assert StopTimeUpdate.uncertainty(stop_update_1) == 300
+      assert StopTimeUpdate.arrival_time(stop_update_2) == 2
+      assert StopTimeUpdate.departure_time(stop_update_2) == 3
+      assert StopTimeUpdate.uncertainty(stop_update_2) == 4
     end
 
     test "can handle missing schedule_relationship" do

--- a/test/concentrate_test.exs
+++ b/test/concentrate_test.exs
@@ -33,6 +33,12 @@ defmodule ConcentrateTest do
       "name_5": {
         "url": "url_5",
         "content_warning_timeout": 3600
+      },
+      "name_6": {
+        "url": "url_6",
+        "headers": {
+          "Authorization": "auth"
+        }
       }
     },
     "gtfs_realtime_enhanced": {
@@ -48,7 +54,8 @@ defmodule ConcentrateTest do
   "sinks": {
     "s3": {
       "bucket": "s3-bucket",
-      "prefix": "bucket_prefix"
+      "prefix": "bucket_prefix",
+      "ignored": "value"
     }
   },
   "file_tap": {
@@ -63,7 +70,8 @@ defmodule ConcentrateTest do
                name_2: {"url_2", fallback_url: "url_fallback"},
                name_3: {"url_3", routes: ~w(a b)},
                name_4: {"url_4", max_future_time: 3600},
-               name_5: {"url_5", content_warning_timeout: 3600}
+               name_5: {"url_5", content_warning_timeout: 3600},
+               name_6: {"url_6", headers: %{"Authorization" => "auth"}}
              }
 
       assert config[:sources][:gtfs_realtime_enhanced] == %{
@@ -109,6 +117,22 @@ defmodule ConcentrateTest do
       config = parse_json_configuration(body)
       assert config[:sources][:gtfs_realtime][:name] == {"url", routes: ~w(a b)}
       assert config[:sources][:gtfs_realtime][:name_2] == "only_url"
+    end
+
+    test "log_level sets Logger.level" do
+      old_level = Logger.level()
+
+      on_exit(fn ->
+        Logger.configure(level: old_level)
+      end)
+
+      body = ~s({"log_level": "info"})
+      _ = parse_json_configuration(body)
+      assert Logger.level() == :info
+
+      body = ~s({"log_level": "debug"})
+      _ = parse_json_configuration(body)
+      assert Logger.level() == :debug
     end
   end
 end


### PR DESCRIPTION
Some upstream sources require passing headers for authentication. These changes allow us to configure those headers and pass them through to the upstream server.