### PR TITLE
don't crash if the VP or STU don't have a stop_id

### DIFF
--- a/lib/concentrate/group_filter/vehicle_stop_match.ex
+++ b/lib/concentrate/group_filter/vehicle_stop_match.ex
@@ -32,7 +32,7 @@ defmodule Concentrate.GroupFilter.VehicleStopMatch do
     vp_stop_id = VehiclePosition.stop_id(vp)
     stu_stop_id = StopTimeUpdate.stop_id(stu)
 
-    if vp_stop_id != stu_stop_id and
+    if is_binary(vp_stop_id) and is_binary(stu_stop_id) and vp_stop_id != stu_stop_id and
          Stops.parent_station_id(vp_stop_id) == Stops.parent_station_id(stu_stop_id) do
       VehiclePosition.update_stop_id(vp, stu_stop_id)
     else

--- a/test/concentrate/group_filter/vehicle_stop_match_test.exs
+++ b/test/concentrate/group_filter/vehicle_stop_match_test.exs
@@ -47,5 +47,23 @@ defmodule Concentrate.GroupFilter.VehicleStopMatchTest do
       vp = VehiclePosition.new(stop_id: "child1", stop_sequence: 1, latitude: 1, longitude: 2)
       assert {_, [^vp], _} = filter({nil, [vp], []})
     end
+
+    test "does nothing if either of the stop IDs are nil" do
+      vp = VehiclePosition.new(stop_id: nil, stop_sequence: 1, latitude: 1, longitude: 2)
+
+      stus = [
+        StopTimeUpdate.new(stop_id: "other", stop_sequence: 1)
+      ]
+
+      assert {_, [^vp], _} = filter({nil, [vp], stus})
+
+      vp = VehiclePosition.new(stop_id: "other", stop_sequence: 1, latitude: 1, longitude: 2)
+
+      stus = [
+        StopTimeUpdate.new(stop_id: nil, stop_sequence: 1)
+      ]
+
+      assert {_, [^vp], _} = filter({nil, [vp], stus})
+    end
   end
 end


### PR DESCRIPTION
Haven't been able to find the root cause of the crash from over the weekend, but this should prevent it from happening again.