### PR TITLE
strip a BOM from the GTFS data

### DIFF
--- a/lib/concentrate/filter/gtfs/unzip.ex
+++ b/lib/concentrate/filter/gtfs/unzip.ex
@@ -9,7 +9,19 @@ defmodule Concentrate.Filter.GTFS.Unzip do
     {:ok, files} = :zip.unzip(binary, [:memory, file_list: @file_list])
 
     for {filename_list, body} <- files do
+      body = strip_bom(body)
       {List.to_string(filename_list), body}
+    end
+  end
+
+  @doc "Strip the (optional) Unicode Byte-Order-Mark from the given binary."
+  def strip_bom(binary) do
+    case :unicode.bom_to_encoding(binary) do
+      {_, 0} ->
+        binary
+
+      {:utf8, length} ->
+        binary_part(binary, length, byte_size(binary) - length)
     end
   end
 end

--- a/test/concentrate/filter/gtfs/unzip_test.exs
+++ b/test/concentrate/filter/gtfs/unzip_test.exs
@@ -20,6 +20,16 @@ defmodule Concentrate.Filter.GTFS.UnzipTest do
     end
   end
 
+  describe "strip_bom/1" do
+    test "does nothing when there's no BOM" do
+      assert strip_bom("1234") == "1234"
+    end
+
+    test "strips a leading BOM" do
+      assert strip_bom("\uFEFF1234") == "1234"
+    end
+  end
+
   defp find_body(files, file_name) do
     Enum.find_value(files, fn
       {^file_name, value} -> value


### PR DESCRIPTION
Handle GTFS files which start with the UTF-8 Byte Order Mark.

References #74 