### PR TITLE
don't treat added stops as always having pickup and drop off

### DIFF
--- a/lib/concentrate/filter/gtfs/pickup_drop_off.ex
+++ b/lib/concentrate/filter/gtfs/pickup_drop_off.ex
@@ -13,23 +13,7 @@ defmodule Concentrate.Filter.GTFS.PickupDropOff do
 
   @spec pickup_drop_off(String.t(), String.t() | non_neg_integer) :: {boolean, boolean} | :unknown
   def pickup_drop_off(trip_id, stop_or_stop_sequence) when is_binary(trip_id) do
-    case {pickup?(trip_id, stop_or_stop_sequence), drop_off?(trip_id, stop_or_stop_sequence)} do
-      {p, d} = t when is_boolean(p) and is_boolean(d) ->
-        t
-
-      _ ->
-        :unknown
-    end
-  end
-
-  defp pickup?(trip_id, stop_or_stop_sequence) when is_binary(trip_id) do
-    key = {:pickup, trip_id, stop_or_stop_sequence}
-    find_value(key)
-  end
-
-  defp drop_off?(trip_id, stop_or_stop_sequence) when is_binary(trip_id) do
-    key = {:drop_off, trip_id, stop_or_stop_sequence}
-    find_value(key)
+    find_value({trip_id, stop_or_stop_sequence})
   end
 
   defp find_value(key) do
@@ -113,11 +97,9 @@ defmodule Concentrate.Filter.GTFS.PickupDropOff do
 
     pickup? = can_pickup_drop_off?(Map.get(row, "pickup_type"))
     drop_off? = can_pickup_drop_off?(Map.get(row, "drop_off_type"))
-    inserts = [pickup: pickup?, drop_off: drop_off?]
 
-    for {key, value} <- inserts,
-        stop_key <- [stop_id, stop_sequence] do
-      {{key, trip_id, stop_key}, value}
+    for stop_key <- [stop_id, stop_sequence] do
+      {{trip_id, stop_key}, {pickup?, drop_off?}}
     end
   end
 end

--- a/lib/concentrate/filter/gtfs/pickup_drop_off.ex
+++ b/lib/concentrate/filter/gtfs/pickup_drop_off.ex
@@ -11,14 +11,23 @@ defmodule Concentrate.Filter.GTFS.PickupDropOff do
     GenStage.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
-  @spec pickup?(String.t(), String.t() | non_neg_integer) :: boolean
-  def pickup?(trip_id, stop_or_stop_sequence) when is_binary(trip_id) do
+  @spec pickup_drop_off(String.t(), String.t() | non_neg_integer) :: {boolean, boolean} | :unknown
+  def pickup_drop_off(trip_id, stop_or_stop_sequence) when is_binary(trip_id) do
+    case {pickup?(trip_id, stop_or_stop_sequence), drop_off?(trip_id, stop_or_stop_sequence)} do
+      {p, d} = t when is_boolean(p) and is_boolean(d) ->
+        t
+
+      _ ->
+        :unknown
+    end
+  end
+
+  defp pickup?(trip_id, stop_or_stop_sequence) when is_binary(trip_id) do
     key = {:pickup, trip_id, stop_or_stop_sequence}
     find_value(key)
   end
 
-  @spec drop_off?(String.t(), String.t() | non_neg_integer) :: boolean
-  def drop_off?(trip_id, stop_or_stop_sequence) when is_binary(trip_id) do
+  defp drop_off?(trip_id, stop_or_stop_sequence) when is_binary(trip_id) do
     key = {:drop_off, trip_id, stop_or_stop_sequence}
     find_value(key)
   end

--- a/lib/concentrate/group_filter/remove_unneeded_times.ex
+++ b/lib/concentrate/group_filter/remove_unneeded_times.ex
@@ -45,10 +45,8 @@ defmodule Concentrate.GroupFilter.RemoveUnneededTimes do
   defp ensure_correct_times_for_last_stu(stu, module, trip_id) do
     # we only remove the departure time from the last stop (excepting SKIPPED stops)
     key = stop_sequence_or_stop_id(stu)
-    pickup? = module.pickup?(trip_id, key)
-    drop_off? = module.drop_off?(trip_id, key)
 
-    case {pickup?, drop_off?} do
+    case module.pickup_drop_off(trip_id, key) do
       {true, true} ->
         ensure_both_times(stu)
 
@@ -69,10 +67,8 @@ defmodule Concentrate.GroupFilter.RemoveUnneededTimes do
 
   defp ensure_correct_times(stu, module, trip_id) do
     key = stop_sequence_or_stop_id(stu)
-    pickup? = module.pickup?(trip_id, key)
-    drop_off? = module.drop_off?(trip_id, key)
 
-    case {pickup?, drop_off?} do
+    case module.pickup_drop_off(trip_id, key) do
       {_, true} ->
         ensure_both_times(stu)
 

--- a/lib/concentrate/group_filter/remove_unneeded_times.ex
+++ b/lib/concentrate/group_filter/remove_unneeded_times.ex
@@ -49,10 +49,21 @@ defmodule Concentrate.GroupFilter.RemoveUnneededTimes do
     drop_off? = module.drop_off?(trip_id, key)
 
     case {pickup?, drop_off?} do
-      {true, true} -> ensure_both_times(stu)
-      {true, false} -> remove_arrival_time(stu)
-      {false, true} -> remove_departure_time(stu)
-      {false, false} -> StopTimeUpdate.skip(stu)
+      {true, true} ->
+        ensure_both_times(stu)
+
+      {true, false} ->
+        remove_arrival_time(stu)
+
+      {false, true} ->
+        remove_departure_time(stu)
+
+      {false, false} ->
+        StopTimeUpdate.skip(stu)
+
+      _ ->
+        # don't make changes if we don't know the pickup/drop-off values
+        stu
     end
   end
 
@@ -71,6 +82,10 @@ defmodule Concentrate.GroupFilter.RemoveUnneededTimes do
 
       {false, false} ->
         StopTimeUpdate.skip(stu)
+
+      _ ->
+        # don't make changes if we don't know the pickup/drop-off values
+        stu
     end
   end
 

--- a/test/concentrate/filter/gtfs/pickup_drop_off_test.exs
+++ b/test/concentrate/filter/gtfs/pickup_drop_off_test.exs
@@ -24,21 +24,23 @@ defmodule Concentrate.Filter.GTFS.PickupDropOffTest do
     setup :supervised
 
     test "true if there's a pickup at the stop on that trip" do
-      assert pickup?("Logan-22-Weekday-trip", "Logan-Subway")
-      assert pickup?("Logan-22-Weekday-trip", "Logan-RentalCarCenter")
+      assert pickup?("Logan-22-Weekday-trip", "Logan-Subway") == true
+      assert pickup?("Logan-22-Weekday-trip", "Logan-RentalCarCenter") == true
       refute pickup?("Logan-22-Weekday-trip", "Logan-A")
-      assert pickup?("Logan-33-Weekday-trip", "Logan-RentalCarCenter")
+      assert pickup?("Logan-33-Weekday-trip", "Logan-RentalCarCenter") == true
     end
 
     test "true if there's a pickup for that stop sequence" do
-      assert pickup?("Logan-22-Weekday-trip", 1)
-      assert pickup?("Logan-22-Weekday-trip", 2)
+      assert pickup?("Logan-22-Weekday-trip", 1) == true
+      assert pickup?("Logan-22-Weekday-trip", 2) == true
       refute pickup?("Logan-22-Weekday-trip", 3)
-      assert pickup?("Logan-33-Weekday-trip", 2)
+      assert pickup?("Logan-33-Weekday-trip", 2) == true
     end
 
-    test "true for unknown trips" do
-      assert pickup?("unknown trip", "unknown stop")
+    test "unknown for unknown trips/stops" do
+      assert pickup?("unknown trip", "unknown stop") == :unknown
+      assert pickup?("Logan-33-Weekday-trip", "unknown stop") == :unknown
+      assert pickup?("Logan-33-Weekday-trip", 4) == :unknown
     end
   end
 
@@ -59,18 +61,18 @@ defmodule Concentrate.Filter.GTFS.PickupDropOffTest do
       assert drop_off?("Logan-33-Weekday-trip", 2)
     end
 
-    test "true for unknown trips" do
-      assert drop_off?("unknown trip", "unknown stop")
+    test "unknown for unknown trips" do
+      assert drop_off?("unknown trip", "unknown stop") == :unknown
     end
   end
 
   describe "missing ETS table" do
-    test "pickup? is true" do
-      assert pickup?("trip", 1)
+    test "pickup? is unknown" do
+      assert pickup?("trip", 1) == :unknown
     end
 
-    test "drop_off? is true" do
-      assert drop_off?("trip", 1)
+    test "drop_off? is unknown" do
+      assert drop_off?("trip", 1) == :unknown
     end
   end
 end

--- a/test/concentrate/filter/gtfs/pickup_drop_off_test.exs
+++ b/test/concentrate/filter/gtfs/pickup_drop_off_test.exs
@@ -24,23 +24,23 @@ defmodule Concentrate.Filter.GTFS.PickupDropOffTest do
     setup :supervised
 
     test "true if there's a pickup at the stop on that trip" do
-      assert pickup?("Logan-22-Weekday-trip", "Logan-Subway") == true
-      assert pickup?("Logan-22-Weekday-trip", "Logan-RentalCarCenter") == true
-      refute pickup?("Logan-22-Weekday-trip", "Logan-A")
-      assert pickup?("Logan-33-Weekday-trip", "Logan-RentalCarCenter") == true
+      assert {true, _} = pickup_drop_off("Logan-22-Weekday-trip", "Logan-Subway")
+      assert {true, _} = pickup_drop_off("Logan-22-Weekday-trip", "Logan-RentalCarCenter")
+      assert {false, _} = pickup_drop_off("Logan-22-Weekday-trip", "Logan-A")
+      assert {true, _} = pickup_drop_off("Logan-33-Weekday-trip", "Logan-RentalCarCenter")
     end
 
     test "true if there's a pickup for that stop sequence" do
-      assert pickup?("Logan-22-Weekday-trip", 1) == true
-      assert pickup?("Logan-22-Weekday-trip", 2) == true
-      refute pickup?("Logan-22-Weekday-trip", 3)
-      assert pickup?("Logan-33-Weekday-trip", 2) == true
+      assert {true, _} = pickup_drop_off("Logan-22-Weekday-trip", 1)
+      assert {true, _} = pickup_drop_off("Logan-22-Weekday-trip", 2)
+      assert {false, _} = pickup_drop_off("Logan-22-Weekday-trip", 3)
+      assert {true, _} = pickup_drop_off("Logan-33-Weekday-trip", 2)
     end
 
     test "unknown for unknown trips/stops" do
-      assert pickup?("unknown trip", "unknown stop") == :unknown
-      assert pickup?("Logan-33-Weekday-trip", "unknown stop") == :unknown
-      assert pickup?("Logan-33-Weekday-trip", 4) == :unknown
+      assert pickup_drop_off("unknown trip", "unknown stop") == :unknown
+      assert pickup_drop_off("Logan-33-Weekday-trip", "unknown stop") == :unknown
+      assert pickup_drop_off("Logan-33-Weekday-trip", 4) == :unknown
     end
   end
 
@@ -48,31 +48,27 @@ defmodule Concentrate.Filter.GTFS.PickupDropOffTest do
     setup :supervised
 
     test "true if there's a drop_off at the stop on that trip" do
-      refute drop_off?("Logan-22-Weekday-trip", "Logan-Subway")
-      assert drop_off?("Logan-22-Weekday-trip", "Logan-RentalCarCenter")
-      assert drop_off?("Logan-22-Weekday-trip", "Logan-A")
-      assert drop_off?("Logan-33-Weekday-trip", "Logan-RentalCarCenter")
+      assert {_, false} = pickup_drop_off("Logan-22-Weekday-trip", "Logan-Subway")
+      assert {_, true} = pickup_drop_off("Logan-22-Weekday-trip", "Logan-RentalCarCenter")
+      assert {_, true} = pickup_drop_off("Logan-22-Weekday-trip", "Logan-A")
+      assert {_, true} = pickup_drop_off("Logan-33-Weekday-trip", "Logan-RentalCarCenter")
     end
 
     test "true if there's a drop_off for that stop sequence" do
-      refute drop_off?("Logan-22-Weekday-trip", 1)
-      assert drop_off?("Logan-22-Weekday-trip", 2)
-      assert drop_off?("Logan-22-Weekday-trip", 3)
-      assert drop_off?("Logan-33-Weekday-trip", 2)
+      assert {_, false} = pickup_drop_off("Logan-22-Weekday-trip", 1)
+      assert {_, true} = pickup_drop_off("Logan-22-Weekday-trip", 2)
+      assert {_, true} = pickup_drop_off("Logan-22-Weekday-trip", 3)
+      assert {_, true} = pickup_drop_off("Logan-33-Weekday-trip", 2)
     end
 
     test "unknown for unknown trips" do
-      assert drop_off?("unknown trip", "unknown stop") == :unknown
+      assert pickup_drop_off("unknown trip", "unknown stop") == :unknown
     end
   end
 
   describe "missing ETS table" do
-    test "pickup? is unknown" do
-      assert pickup?("trip", 1) == :unknown
-    end
-
-    test "drop_off? is unknown" do
-      assert drop_off?("trip", 1) == :unknown
+    test "pickup_drop_off is unknown" do
+      assert pickup_drop_off("trip", 1) == :unknown
     end
   end
 end

--- a/test/concentrate/group_filter/remove_unneeded_times_test.exs
+++ b/test/concentrate/group_filter/remove_unneeded_times_test.exs
@@ -6,13 +6,17 @@ defmodule Concentrate.GroupFilter.RemoveUnneededTimesTest do
 
   defmodule FakePickupDropOff do
     @moduledoc "Fake implementation of Filter.GTFS.PickupDropOff"
+    def pickup?("trip", 1), do: true
+    def pickup?("trip", 4), do: true
     def pickup?("trip", 5), do: false
     def pickup?("trip", 6), do: false
-    def pickup?(_, _), do: true
+    def pickup?(_, _), do: :unknown
 
     def drop_off?("trip", 1), do: false
+    def drop_off?("trip", 4), do: true
+    def drop_off?("trip", 5), do: true
     def drop_off?("trip", 6), do: false
-    def drop_off?(_, _), do: true
+    def drop_off?(_, _), do: :unknown
   end
 
   @module __MODULE__.FakePickupDropOff
@@ -22,12 +26,15 @@ defmodule Concentrate.GroupFilter.RemoveUnneededTimesTest do
   @stu StopTimeUpdate.new(
          trip_id: "trip",
          arrival_time: @arrival_time,
-         departure_time: @departure_time
+         departure_time: @departure_time,
+         stop_sequence: 4
        )
 
   describe "filter/1" do
     test "a stop time update with a different stop_sequence isn't modified" do
-      group = {@tu, [], [@stu]}
+      stu = StopTimeUpdate.update(@stu, stop_sequence: 7, arrival_time: nil)
+      stu_2 = StopTimeUpdate.update(@stu, stop_sequence: 8, departure_time: nil)
+      group = {@tu, [], [stu, stu_2]}
       assert filter(group, @module) == group
     end
 

--- a/test/concentrate/group_filter/remove_unneeded_times_test.exs
+++ b/test/concentrate/group_filter/remove_unneeded_times_test.exs
@@ -6,17 +6,12 @@ defmodule Concentrate.GroupFilter.RemoveUnneededTimesTest do
 
   defmodule FakePickupDropOff do
     @moduledoc "Fake implementation of Filter.GTFS.PickupDropOff"
-    def pickup?("trip", 1), do: true
-    def pickup?("trip", 4), do: true
-    def pickup?("trip", 5), do: false
-    def pickup?("trip", 6), do: false
-    def pickup?(_, _), do: :unknown
 
-    def drop_off?("trip", 1), do: false
-    def drop_off?("trip", 4), do: true
-    def drop_off?("trip", 5), do: true
-    def drop_off?("trip", 6), do: false
-    def drop_off?(_, _), do: :unknown
+    def pickup_drop_off("trip", 1), do: {true, false}
+    def pickup_drop_off("trip", 4), do: {true, true}
+    def pickup_drop_off("trip", 5), do: {false, true}
+    def pickup_drop_off("trip", 6), do: {false, false}
+    def pickup_drop_off(_, _), do: :unknown
   end
 
   @module __MODULE__.FakePickupDropOff


### PR DESCRIPTION
Previously, we'd treat extra stop IDs as being able to both pickup and drop
off riders. However, that's not always true: if we're running the vehicle
further, it may have extra stops beyond the sequence specified in GTFS. In
that case, we don't want to make any changes.
