### PR TITLE
revert to Erlang 21.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir v1.8.1-otp-21
-erlang 21.2.5
+erlang 21.1.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,28 @@
-FROM elixir:1.8-alpine AS builder
+FROM erlang:21.1-alpine AS builder
+
+# Install Elixir
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.8.1" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="de8c636ea999392496ccd9a204ccccbc8cb7f417d948fd12692cda2bd02d9822" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		make \
+	' \
+	&& apk add --no-cache --virtual .build-deps $buildDeps \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& apk del .build-deps
 
 WORKDIR /root
 
@@ -18,9 +42,9 @@ WORKDIR /root
 RUN elixir --erl "-smp enable" /usr/local/bin/mix do deps.get --only prod, compile, release --verbose
 
 # Second stage: uses the built .tgz to get the files over
-FROM alpine:3.9
+FROM alpine:3.8
 
-RUN apk add --update bash \
+RUN apk add --update libssl1.0 ncurses-libs bash \
 	&& rm -rf /var/cache/apk
 
 # Set environment


### PR DESCRIPTION
Seeing if going back to 21.1 avoids the SSL errors we've been seeing.