### PR TITLE
feat: track the same vehicle for multiple TripUpdates

### DIFF
--- a/lib/concentrate/encoder/gtfs_realtime_helpers.ex
+++ b/lib/concentrate/encoder/gtfs_realtime_helpers.ex
@@ -186,7 +186,7 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
         schedule_relationship: schedule_relationship(TripUpdate.schedule_relationship(update))
       })
 
-    vehicle = trip_update_vehicle(vps)
+    vehicle = trip_update_vehicle(update, vps)
 
     stop_time_update =
       case stus do
@@ -225,15 +225,19 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
     []
   end
 
-  defp trip_update_vehicle([]) do
-    nil
-  end
-
-  defp trip_update_vehicle([vp | _]) do
+  defp trip_update_vehicle(_update, [vp | _]) do
     drop_nil_values(%{
       id: VehiclePosition.id(vp),
       label: VehiclePosition.label(vp),
       license_plate: VehiclePosition.license_plate(vp)
     })
+  end
+
+  defp trip_update_vehicle(update, []) do
+    if vehicle_id = TripUpdate.vehicle_id(update) do
+      %{id: vehicle_id}
+    else
+      nil
+    end
   end
 end

--- a/lib/concentrate/parser/gtfs_realtime.ex
+++ b/lib/concentrate/parser/gtfs_realtime.ex
@@ -134,7 +134,7 @@ defmodule Concentrate.Parser.GTFSRealtime do
   defp times_less_than_max?(time, nil, max), do: time <= max
   defp times_less_than_max?(_, time, max), do: time <= max
 
-  defp decode_trip_descriptor(%{trip: trip}) do
+  defp decode_trip_descriptor(%{trip: trip} = descriptor) do
     [
       TripUpdate.new(
         trip_id: Map.get(trip, :trip_id),
@@ -142,7 +142,8 @@ defmodule Concentrate.Parser.GTFSRealtime do
         direction_id: Map.get(trip, :direction_id),
         start_date: date(Map.get(trip, :start_date)),
         start_time: Map.get(trip, :start_time),
-        schedule_relationship: Map.get(trip, :schedule_relationship, :SCHEDULED)
+        schedule_relationship: Map.get(trip, :schedule_relationship, :SCHEDULED),
+        vehicle_id: decode_trip_descriptor_vehicle_id(descriptor)
       )
     ]
   end
@@ -150,6 +151,9 @@ defmodule Concentrate.Parser.GTFSRealtime do
   defp decode_trip_descriptor(_) do
     []
   end
+
+  defp decode_trip_descriptor_vehicle_id(%{vehicle: %{id: vehicle_id}}), do: vehicle_id
+  defp decode_trip_descriptor_vehicle_id(_), do: nil
 
   defp date(nil) do
     nil

--- a/lib/concentrate/trip_update.ex
+++ b/lib/concentrate/trip_update.ex
@@ -10,6 +10,7 @@ defmodule Concentrate.TripUpdate do
     :direction_id,
     :start_date,
     :start_time,
+    :vehicle_id,
     schedule_relationship: :SCHEDULED
   ])
 
@@ -28,6 +29,7 @@ defmodule Concentrate.TripUpdate do
           direction_id: first.direction_id || second.direction_id,
           start_date: first.start_date || second.start_date,
           start_time: first.start_time || second.start_time,
+          vehicle_id: first.vehicle_id || second.vehicle_id,
           schedule_relationship:
             if first.schedule_relationship == :SCHEDULED do
               second.schedule_relationship

--- a/test/concentrate/parser/gtfs_realtime_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_test.exs
@@ -59,7 +59,10 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
           start_time: "26:15:09",
           schedule_relationship: :ADDED
         },
-        stop_time_update: [%{}]
+        stop_time_update: [%{}],
+        vehicle: %{
+          id: "vehicle_id"
+        }
       }
 
       [tu, _] = decode_trip_update(update, %Options{})
@@ -71,6 +74,7 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
                  direction_id: 1,
                  start_date: {2017, 12, 20},
                  start_time: "26:15:09",
+                 vehicle_id: "vehicle_id",
                  schedule_relationship: :ADDED
                )
     end


### PR DESCRIPTION
The vehicle itself is only on a single trip at a time, but a TripUpdate can
predict that a vehicle will be running that trip in the future. Previously,
we'd throw that information away, relying on the information from the
VehiclePosition to hold the trip information. Now, we also keep track of
the vehicle's ID on the TripUpdate, and use that if there isn't a
VehiclePosition with that trip ID.