### PR TITLE
feat: use dumb-init to run the main process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@ FROM erlang:21.1-alpine AS builder
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.8.2" \
-    LANG=C.UTF-8
+    LANG=C.UTF-8 \
+    DUMB_INIT_VERSION="1.2.2"
 
 RUN set -xe \
     && ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
     && ELIXIR_DOWNLOAD_SHA256="cf9bf0b2d92bc4671431e3fe1d1b0a0e5125f1a942cc4fdf7914b74f04efb835" \
+    && DUMB_INIT_SHA256="37f2c1f0372a45554f1b89924fbb134fc24c3756efaedf11e07f599494e0eff9" \
     && buildDeps=' \
         ca-certificates \
         curl \
@@ -22,6 +24,9 @@ RUN set -xe \
     && rm elixir-src.tar.gz \
     && cd /usr/local/src/elixir \
     && make install clean \
+    && curl -fsL -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64 \
+    && echo "$DUMB_INIT_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
+    && chmod +x /usr/local/bin/dumb-init \
     && apk del .build-deps
 
 WORKDIR /root
@@ -53,9 +58,10 @@ ENV MIX_ENV=prod TERM=xterm LANG=C.UTF-8 REPLACE_OS_VARS=true
 WORKDIR /root/
 
 COPY --from=builder /root/_build/prod/rel /root/rel
+COPY --from=builder /usr/local/bin/dumb-init /usr/local/bin/dumb-init
 
 # Ensure SSL support is enabled
 RUN /root/rel/concentrate/bin/concentrate eval ":crypto.supports()"
 
 HEALTHCHECK CMD ["/root/rel/concentrate/bin/concentrate", "rpc", "--mfa", "Concentrate.Health.healthy?/0"]
-CMD ["/root/rel/concentrate/bin/concentrate", "foreground"]
+CMD ["/usr/local/bin/dumb-init", "/root/rel/concentrate/bin/concentrate", "foreground"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,25 +4,25 @@ FROM erlang:21.1-alpine AS builder
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.8.2" \
-	LANG=C.UTF-8
+    LANG=C.UTF-8
 
 RUN set -xe \
-	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="cf9bf0b2d92bc4671431e3fe1d1b0a0e5125f1a942cc4fdf7914b74f04efb835" \
-	&& buildDeps=' \
-		ca-certificates \
-		curl \
-		make \
-	' \
-	&& apk add --no-cache --virtual .build-deps $buildDeps \
-	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
-	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
-	&& mkdir -p /usr/local/src/elixir \
-	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
-	&& rm elixir-src.tar.gz \
-	&& cd /usr/local/src/elixir \
-	&& make install clean \
-	&& apk del .build-deps
+    && ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+    && ELIXIR_DOWNLOAD_SHA256="cf9bf0b2d92bc4671431e3fe1d1b0a0e5125f1a942cc4fdf7914b74f04efb835" \
+    && buildDeps=' \
+        ca-certificates \
+        curl \
+        make \
+    ' \
+    && apk add --no-cache --virtual .build-deps $buildDeps \
+    && curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+    && echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/local/src/elixir \
+    && tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+    && rm elixir-src.tar.gz \
+    && cd /usr/local/src/elixir \
+    && make install clean \
+    && apk del .build-deps
 
 WORKDIR /root
 
@@ -45,7 +45,7 @@ RUN elixir --erl "-smp enable" /usr/local/bin/mix do deps.get --only prod, compi
 FROM alpine:3.8
 
 RUN apk add --update libssl1.0 ncurses-libs bash \
-	&& rm -rf /var/cache/apk
+    && rm -rf /var/cache/apk
 
 # Set environment
 ENV MIX_ENV=prod TERM=xterm LANG=C.UTF-8 REPLACE_OS_VARS=true


### PR DESCRIPTION
Per
https://engineeringblog.yelp.com/2016/01/dumb-init-an-init-for-docker.html,
running the Erlang VM as PID 1 may have some issues with reaping child
processes. `dumb-init` replaces PID 1 and runs our VM as another PID.