### PR TITLE
fix: don't strip empty CANCELED TripUpdates when merging

### DIFF
--- a/test/concentrate/merge_filter_test.exs
+++ b/test/concentrate/merge_filter_test.exs
@@ -99,6 +99,22 @@ defmodule Concentrate.MergeFilterTest do
       assert events == [expected]
     end
 
+    test "allows a CANCELED TripUpdate with no StopTimeUpdates" do
+      filter = fn group -> group end
+      from = make_from()
+      {_, state, _} = init(group_filters: [filter])
+      {_, state} = handle_subscribe(:producer, [], from, state)
+
+      data = [
+        trip = TripUpdate.new(trip_id: "trip", schedule_relationship: :CANCELED)
+      ]
+
+      expected = [{trip, [], []}]
+      {:noreply, [], state} = handle_events([data], from, state)
+      {:noreply, events, _state} = handle_info(:timeout, state)
+      assert events == [expected]
+    end
+
     test "when Logging debug messages, does not crash" do
       log_level = Logger.level()
 


### PR DESCRIPTION
According to the [GTFS-RT spec](https://gtfs.org/reference/realtime/v2/#message-tripupdate):

> At least one stop_time_update must be provided for the trip unless the
trip.schedule_relationship is CANCELED - if the trip is canceled, no
stop_time_updates need to be provided.

We allowing this when we grouped the TripUpdates, but not when filtering.