### PR TITLE
feat: round vehicle speeds to one decimal place, don't truncate them

### DIFF
--- a/lib/concentrate/filter/round_speed_and_bearing.ex
+++ b/lib/concentrate/filter/round_speed_and_bearing.ex
@@ -1,6 +1,7 @@
-defmodule Concentrate.Filter.RoundSpeedToInteger do
+defmodule Concentrate.Filter.RoundSpeedAndBearing do
   @moduledoc """
-  Rounds the speed of vehicles to an integer, or nil if it's less than 1 m/s.
+  Rounds the speed and bearing. The speed is rounded to a float with precision
+  of 1 decimal place, and set to nil if < 1 m/s. The bearing is truncated.
   """
   @behaviour Concentrate.Filter
   alias Concentrate.VehiclePosition
@@ -11,7 +12,7 @@ defmodule Concentrate.Filter.RoundSpeedToInteger do
       case VehiclePosition.speed(vp) do
         nil -> nil
         small when small < 1 -> nil
-        other -> trunc(other)
+        other -> Float.round(other, 1)
       end
 
     bearing =

--- a/test/concentrate/filter/round_speed_and_bearing_test.exs
+++ b/test/concentrate/filter/round_speed_and_bearing_test.exs
@@ -1,7 +1,7 @@
-defmodule Concentrate.Filter.RoundSpeedToIntegerTest do
+defmodule Concentrate.Filter.RoundSpeedAndBearingTest do
   @moduledoc false
   use ExUnit.Case, async: true
-  import Concentrate.Filter.RoundSpeedToInteger
+  import Concentrate.Filter.RoundSpeedAndBearing
   alias Concentrate.VehiclePosition
 
   describe "filter/1" do
@@ -10,10 +10,10 @@ defmodule Concentrate.Filter.RoundSpeedToIntegerTest do
       assert {:cont, ^vp} = filter(vp)
     end
 
-    test "a vehicle position with a float speed or bearing is truncated" do
-      vp = VehiclePosition.new(speed: 1.5, bearing: -123.45, latitude: 1, longitude: 1)
+    test "a vehicle position has its float speed rounded and its bearing truncated" do
+      vp = VehiclePosition.new(speed: 1.577, bearing: -123.45, latitude: 1, longitude: 1)
       {:cont, new_vp} = filter(vp)
-      assert VehiclePosition.speed(new_vp) == 1
+      assert VehiclePosition.speed(new_vp) == 1.6
       assert VehiclePosition.bearing(new_vp) == -123
     end
 

--- a/test/concentrate/parser/helpers_test.exs
+++ b/test/concentrate/parser/helpers_test.exs
@@ -17,7 +17,7 @@ defmodule Concentrate.Parser.HelpersTest do
           id: "1",
           latitude: 1,
           longitude: 2,
-          speed: 5
+          speed: 5.2
         )
 
       assert [^tu, new_vp] = drop_fields([tu, vp], @options.drop_fields)


### PR DESCRIPTION
This changes the VehiclePosition filter from truncating to rounding to one decimal place. 

It does change the value from an int to a float, so it _could_ be a breaking change, though the test suite passed and I didn't see any immediate way it would cause issues in the API.

Since the module was named `RoundSpeedToInteger`, I had to rename it (and then rename the file as well). I thought of just `RoundSpeed` at first, but the module also rounds the bearing, so I figured I could add that to the name, too. (Or tease it out into a separate `RoundBearing` filter, but since they were already together I figured I should just leave it that way.)