### PR TITLE
Include route_pattern_id in TripUpdate

### DIFF
--- a/lib/concentrate/encoder/gtfs_realtime_helpers.ex
+++ b/lib/concentrate/encoder/gtfs_realtime_helpers.ex
@@ -95,8 +95,8 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
 
   Takes a function to turn a StopTimeUpdate struct into the GTFS-RT version.
   """
-  def trip_update_feed_entity(groups, stop_time_update_fn) do
-    Enum.flat_map(groups, &build_trip_update_entity(&1, stop_time_update_fn))
+  def trip_update_feed_entity(groups, stop_time_update_fn, enhanced \\ false) do
+    Enum.flat_map(groups, &build_trip_update_entity(&1, stop_time_update_fn, enhanced))
   end
 
   @doc """
@@ -172,19 +172,32 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
     {tu, vps, [stu | stus]}
   end
 
-  defp build_trip_update_entity({%TripUpdate{} = update, vps, stus}, stop_time_update_fn) do
+  defp build_trip_update_entity(
+         {%TripUpdate{} = update, vps, stus},
+         stop_time_update_fn,
+         enhanced
+       ) do
     trip_id = TripUpdate.trip_id(update)
     id = trip_id || "#{:erlang.phash2(update)}"
 
+    trip_data = %{
+      trip_id: trip_id,
+      route_id: TripUpdate.route_id(update),
+      direction_id: TripUpdate.direction_id(update),
+      start_time: TripUpdate.start_time(update),
+      start_date: encode_date(TripUpdate.start_date(update)),
+      schedule_relationship: schedule_relationship(TripUpdate.schedule_relationship(update))
+    }
+
     trip =
-      drop_nil_values(%{
-        trip_id: trip_id,
-        route_id: TripUpdate.route_id(update),
-        direction_id: TripUpdate.direction_id(update),
-        start_time: TripUpdate.start_time(update),
-        start_date: encode_date(TripUpdate.start_date(update)),
-        schedule_relationship: schedule_relationship(TripUpdate.schedule_relationship(update))
-      })
+      trip_data
+      |> Map.merge(
+        case enhanced do
+          true -> %{route_pattern_id: TripUpdate.route_pattern_id(update)}
+          _ -> %{}
+        end
+      )
+      |> drop_nil_values()
 
     vehicle = trip_update_vehicle(update, vps)
 
@@ -221,7 +234,7 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
     end
   end
 
-  defp build_trip_update_entity(_, _) do
+  defp build_trip_update_entity(_, _, _) do
     []
   end
 

--- a/lib/concentrate/encoder/trip_updates_enhanced.ex
+++ b/lib/concentrate/encoder/trip_updates_enhanced.ex
@@ -3,17 +3,21 @@ defmodule Concentrate.Encoder.TripUpdatesEnhanced do
   Encodes a list of parsed data into an enhanced.pb file.
   """
   @behaviour Concentrate.Encoder
-  alias Concentrate.StopTimeUpdate
+  alias Concentrate.{StopTimeUpdate, TripUpdate}
   import Concentrate.Encoder.GTFSRealtimeHelpers
 
   @impl Concentrate.Encoder
   def encode_groups(groups) when is_list(groups) do
     message = %{
       header: feed_header(),
-      entity: trip_update_feed_entity(groups, &build_stop_time_update/1, true)
+      entity: trip_update_feed_entity(groups, &build_stop_time_update/1, &enhanced_data/1)
     }
 
     Jason.encode!(message)
+  end
+
+  defp enhanced_data(update) do
+    %{route_pattern_id: TripUpdate.route_pattern_id(update)}
   end
 
   defp build_stop_time_update(update) do

--- a/lib/concentrate/encoder/trip_updates_enhanced.ex
+++ b/lib/concentrate/encoder/trip_updates_enhanced.ex
@@ -10,7 +10,7 @@ defmodule Concentrate.Encoder.TripUpdatesEnhanced do
   def encode_groups(groups) when is_list(groups) do
     message = %{
       header: feed_header(),
-      entity: trip_update_feed_entity(groups, &build_stop_time_update/1)
+      entity: trip_update_feed_entity(groups, &build_stop_time_update/1, true)
     }
 
     Jason.encode!(message)

--- a/lib/concentrate/parser/gtfs_realtime.ex
+++ b/lib/concentrate/parser/gtfs_realtime.ex
@@ -122,6 +122,7 @@ defmodule Concentrate.Parser.GTFSRealtime do
       TripUpdate.new(
         trip_id: Map.get(trip, :trip_id),
         route_id: Map.get(trip, :route_id),
+        route_pattern_id: Map.get(trip, :route_pattern_id),
         direction_id: Map.get(trip, :direction_id),
         start_date: date(Map.get(trip, :start_date)),
         start_time: Map.get(trip, :start_time),

--- a/lib/concentrate/parser/gtfs_realtime.ex
+++ b/lib/concentrate/parser/gtfs_realtime.ex
@@ -122,7 +122,6 @@ defmodule Concentrate.Parser.GTFSRealtime do
       TripUpdate.new(
         trip_id: Map.get(trip, :trip_id),
         route_id: Map.get(trip, :route_id),
-        route_pattern_id: Map.get(trip, :route_pattern_id),
         direction_id: Map.get(trip, :direction_id),
         start_date: date(Map.get(trip, :start_date)),
         start_time: Map.get(trip, :start_time),

--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -157,6 +157,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
       TripUpdate.new(
         trip_id: Map.get(trip, "trip_id"),
         route_id: Map.get(trip, "route_id"),
+        route_pattern_id: Map.get(trip, "route_pattern_id"),
         direction_id: Map.get(trip, "direction_id"),
         start_date: date(Map.get(trip, "start_date")),
         start_time: Map.get(trip, "start_time"),

--- a/lib/concentrate/trip_update.ex
+++ b/lib/concentrate/trip_update.ex
@@ -7,6 +7,7 @@ defmodule Concentrate.TripUpdate do
   defstruct_accessors([
     :trip_id,
     :route_id,
+    :route_pattern_id,
     :direction_id,
     :start_date,
     :start_time,
@@ -26,6 +27,7 @@ defmodule Concentrate.TripUpdate do
       %{
         first
         | route_id: first.route_id || second.route_id,
+          route_pattern_id: first.route_pattern_id || second.route_pattern_id,
           direction_id: first.direction_id || second.direction_id,
           start_date: first.start_date || second.start_date,
           start_time: first.start_time || second.start_time,

--- a/test/concentrate/encoder/trip_updates_enhanced_test.exs
+++ b/test/concentrate/encoder/trip_updates_enhanced_test.exs
@@ -85,5 +85,26 @@ defmodule Concentrate.Encoder.TripUpdatesEnhancedTest do
       refute "schedule_relationship" in Map.keys(trip)
       refute "schedule_relationship" in Map.keys(update)
     end
+
+    test "trips with route_pattern_id present have that field" do
+      parsed = [
+        TripUpdate.new(trip_id: "trip", route_pattern_id: "pattern"),
+        StopTimeUpdate.new(trip_id: "trip", stop_id: "stop")
+      ]
+
+      encoded = Jason.decode!(encode_groups(group(parsed)))
+
+      assert %{
+               "entity" => [
+                 %{
+                   "trip_update" => %{
+                     "trip" => %{
+                       "route_pattern_id" => "pattern"
+                     }
+                   }
+                 }
+               ]
+             } = encoded
+    end
   end
 end

--- a/test/concentrate/encoder/trip_updates_test.exs
+++ b/test/concentrate/encoder/trip_updates_test.exs
@@ -97,5 +97,22 @@ defmodule Concentrate.Encoder.TripUpdatesTest do
       round_tripped = GTFSRealtime.parse(encode_groups(group(interspersed)), [])
       assert Enum.sort(round_tripped) == Enum.sort(decoded)
     end
+
+    test "trips with route_pattern_id present don't have that field" do
+      initial = [
+        TripUpdate.new(trip_id: "trip", route_pattern_id: "pattern"),
+        StopTimeUpdate.new(trip_id: "trip", stop_id: "stop")
+      ]
+
+      decoded = :gtfs_realtime_proto.decode_msg(encode_groups(group(initial)), :FeedMessage, [])
+
+      %{
+        entity: [
+          %{trip_update: %{trip: trip}}
+        ]
+      } = decoded
+
+      refute "route_pattern_id" in Map.keys(trip)
+    end
   end
 end

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -220,6 +220,20 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
       assert [_] = decode_trip_update(update, Helpers.parse_options(routes: ["route"]))
       assert [] = decode_trip_update(update, Helpers.parse_options(excluded_routes: ["route"]))
     end
+
+    test "can include a route_pattern_id in the trip descriptor" do
+      map = %{
+        "trip" => %{
+          "trip_id" => "trip",
+          "route_id" => "route",
+          "route_pattern_id" => "pattern"
+        },
+        "stop_time_update" => []
+      }
+
+      [tu] = decode_trip_update(map, Helpers.parse_options([]))
+      assert TripUpdate.route_pattern_id(tu) == "pattern"
+    end
   end
 
   describe "decode_vehicle/1" do

--- a/test/concentrate/trip_update_test.exs
+++ b/test/concentrate/trip_update_test.exs
@@ -10,6 +10,7 @@ defmodule Concentrate.TripUpdateTest do
         new(
           trip_id: "trip",
           route_id: "route",
+          route_pattern_id: "pattern",
           start_date: ~D[2017-12-20]
         )
 
@@ -25,6 +26,7 @@ defmodule Concentrate.TripUpdateTest do
         new(
           trip_id: "trip",
           route_id: "route",
+          route_pattern_id: "pattern",
           direction_id: 0,
           start_date: ~D[2017-12-20],
           start_time: ~T[12:00:00],


### PR DESCRIPTION
If `route_pattern_id` are present in `TripUpdate`, parse them and include them in enhanced output.