### PR TITLE
fix: filter out empty StopTimeUpdate records

### DIFF
--- a/lib/concentrate/encoder/gtfs_realtime_helpers.ex
+++ b/lib/concentrate/encoder/gtfs_realtime_helpers.ex
@@ -198,7 +198,7 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
 
     stop_time_update =
       case stus do
-        [_ | _] -> Enum.map(stus, stop_time_update_fn)
+        [_ | _] -> render_stop_time_updates(stus, stop_time_update_fn)
         [] -> nil
       end
 
@@ -231,6 +231,18 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
 
   defp build_trip_update_entity(_, _, _) do
     []
+  end
+
+  defp render_stop_time_updates(stus, stop_time_update_fn) do
+    Enum.flat_map(stus, fn stu ->
+      case stop_time_update_fn.(stu) do
+        :skip ->
+          []
+
+        update ->
+          [update]
+      end
+    end)
   end
 
   defp trip_update_vehicle(_update, [vp | _]) do

--- a/lib/concentrate/encoder/trip_updates.ex
+++ b/lib/concentrate/encoder/trip_updates.ex
@@ -17,14 +17,24 @@ defmodule Concentrate.Encoder.TripUpdates do
   end
 
   def build_stop_time_update(update) do
-    drop_nil_values(%{
-      stop_id: StopTimeUpdate.stop_id(update),
-      stop_sequence: StopTimeUpdate.stop_sequence(update),
-      arrival:
-        stop_time_event(StopTimeUpdate.arrival_time(update), StopTimeUpdate.uncertainty(update)),
-      departure:
-        stop_time_event(StopTimeUpdate.departure_time(update), StopTimeUpdate.uncertainty(update)),
-      schedule_relationship: schedule_relationship(StopTimeUpdate.schedule_relationship(update))
-    })
+    arrival =
+      stop_time_event(StopTimeUpdate.arrival_time(update), StopTimeUpdate.uncertainty(update))
+
+    departure =
+      stop_time_event(StopTimeUpdate.departure_time(update), StopTimeUpdate.uncertainty(update))
+
+    relationship = schedule_relationship(StopTimeUpdate.schedule_relationship(update))
+
+    if is_map(arrival) or is_map(departure) or relationship != nil do
+      drop_nil_values(%{
+        stop_id: StopTimeUpdate.stop_id(update),
+        stop_sequence: StopTimeUpdate.stop_sequence(update),
+        arrival: arrival,
+        departure: departure,
+        schedule_relationship: relationship
+      })
+    else
+      :skip
+    end
   end
 end

--- a/test/concentrate/encoder/trip_updates/json_test.exs
+++ b/test/concentrate/encoder/trip_updates/json_test.exs
@@ -16,8 +16,8 @@ defmodule Concentrate.Encoder.TripUpdates.JSONTest do
       stop_time_updates =
         Enum.shuffle([
           StopTimeUpdate.new(trip_id: "1", schedule_relationship: :SKIPPED),
-          StopTimeUpdate.new(trip_id: "2"),
-          StopTimeUpdate.new(trip_id: "3")
+          StopTimeUpdate.new(trip_id: "2", departure_time: 2),
+          StopTimeUpdate.new(trip_id: "3", arrival_time: 3)
         ])
 
       initial = trip_updates ++ stop_time_updates
@@ -46,7 +46,12 @@ defmodule Concentrate.Encoder.TripUpdates.JSONTest do
     test "trips/updates with schedule_relationship SCHEDULED don't have that field" do
       parsed = [
         TripUpdate.new(trip_id: "trip", schedule_relationship: :SCHEDULED),
-        StopTimeUpdate.new(trip_id: "trip", stop_id: "stop", schedule_relationship: :SCHEDULED)
+        StopTimeUpdate.new(
+          trip_id: "trip",
+          stop_id: "stop",
+          schedule_relationship: :SCHEDULED,
+          arrival_time: 1
+        )
       ]
 
       encoded = parsed |> group() |> encode_groups() |> Jason.decode!()


### PR DESCRIPTION
For StopTimeUpdate records in the Protobuf export, we don't include the
`status` field. This can result in records like this:

```
entity {
  id: "CR-Weekday-Fall-19-616"
  trip_update {
    trip {
      trip_id: "CR-Weekday-Fall-19-616"
      start_date: "20191210"
      route_id: "CR-Needham"
      direction_id: 1
    }
    stop_time_update {
      stop_sequence: 11
      stop_id: "South Station"
    }
  }
}

```

That StopTimeUpdate does not have any useful information, so instead we drop
it from the rendered version. This had some knock-on effects on test cases,
where we weren't providing any data for StopTimeUpdates we expected to be in
the output.