### PR TITLE
fix: don't render empty TripUpdates

### DIFF
--- a/lib/concentrate/encoder/gtfs_realtime_helpers.ex
+++ b/lib/concentrate/encoder/gtfs_realtime_helpers.ex
@@ -203,7 +203,7 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
       end
 
     cond do
-      is_list(stop_time_update) ->
+      match?([_ | _], stop_time_update) ->
         [
           %{
             id: id,

--- a/test/concentrate/encoder/producer_consumer_test.exs
+++ b/test/concentrate/encoder/producer_consumer_test.exs
@@ -11,7 +11,12 @@ defmodule Concentrate.Encoder.ProducerConsumerTest do
       {_, state, _} =
         init(files: [{"TripUpdates.pb", TripUpdates}, {"VehiclePositions.pb", VehiclePositions}])
 
-      data = group([TripUpdate.new(trip_id: "trip"), StopTimeUpdate.new(trip_id: "trip")])
+      data =
+        group([
+          TripUpdate.new(trip_id: "trip"),
+          StopTimeUpdate.new(trip_id: "trip", departure_time: 1)
+        ])
+
       {:noreply, events, _state, :hibernate} = handle_events([[], data], :from, state)
 
       assert [{"TripUpdates.pb", trip_update}, {"VehiclePositions.pb", vehicle_positions}] =

--- a/test/concentrate/encoder/trip_updates_test.exs
+++ b/test/concentrate/encoder/trip_updates_test.exs
@@ -86,7 +86,9 @@ defmodule Concentrate.Encoder.TripUpdatesTest do
         TripUpdate.new(trip_id: "1"),
         StopTimeUpdate.new(trip_id: "1", stop_sequence: 1, status: "status"),
         StopTimeUpdate.new(trip_id: "1", stop_sequence: 2, departure_time: 1, status: "boarding"),
-        StopTimeUpdate.new(trip_id: "1", stop_sequence: 3, arrival_time: 2)
+        StopTimeUpdate.new(trip_id: "1", stop_sequence: 3, arrival_time: 2),
+        TripUpdate.new(trip_id: "2"),
+        StopTimeUpdate.new(trip_id: "2", status: "status")
       ]
 
       decoded = GTFSRealtime.parse(encode_groups(group(initial)), [])
@@ -121,7 +123,7 @@ defmodule Concentrate.Encoder.TripUpdatesTest do
     test "trips with route_pattern_id present don't have that field" do
       initial = [
         TripUpdate.new(trip_id: "trip", route_pattern_id: "pattern"),
-        StopTimeUpdate.new(trip_id: "trip", stop_id: "stop")
+        StopTimeUpdate.new(trip_id: "trip", stop_id: "stop", departure_time: 1)
       ]
 
       decoded = :gtfs_realtime_proto.decode_msg(encode_groups(group(initial)), :FeedMessage, [])


### PR DESCRIPTION
Once we started filtering out some StopTimeUpdate values, it became possible
to end up with an empty list of StopTimeUpdates. Since we don't have any
updates, there's nothing to do with that TripUpdate and we drop it entirely.

This results in failures for some other tests, where there wasn't enough
information in the StopTimeUpdate to render.