### PR TITLE
fix: handle invalid `start_time`

### DIFF
--- a/lib/concentrate/parser/gtfs_realtime.ex
+++ b/lib/concentrate/parser/gtfs_realtime.ex
@@ -124,7 +124,7 @@ defmodule Concentrate.Parser.GTFSRealtime do
         route_id: Map.get(trip, :route_id),
         direction_id: Map.get(trip, :direction_id),
         start_date: date(Map.get(trip, :start_date)),
-        start_time: Map.get(trip, :start_time),
+        start_time: time(Map.get(trip, :start_time)),
         schedule_relationship: Map.get(trip, :schedule_relationship, :SCHEDULED),
         vehicle_id: decode_trip_descriptor_vehicle_id(descriptor)
       )
@@ -148,6 +148,23 @@ defmodule Concentrate.Parser.GTFSRealtime do
       String.to_integer(month_str),
       String.to_integer(day_str)
     }
+  end
+
+  defp time(nil) do
+    nil
+  end
+
+  defp time(<<_hour::binary-2, ":", _minute::binary-2, ":", _second::binary-2>> = bin) do
+    bin
+  end
+
+  defp time(<<_hour::binary-1, ":", _minute::binary-2, ":", _second::binary-2>> = bin) do
+    "0" <> bin
+  end
+
+  defp time(bin) when is_binary(bin) do
+    # invalid time, treat as missing
+    nil
   end
 
   defp decode_alert(%{id: id, alert: %{} = alert}) do

--- a/test/concentrate/parser/gtfs_realtime_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_test.exs
@@ -229,6 +229,48 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
 
       assert [] = decode_trip_update(update, %Options{routes: {:ok, ["keeping"]}})
     end
+
+    test "can handle start_time with a single digit hour" do
+      update = %{
+        trip: %{
+          trip_id: "trip",
+          route_id: "route",
+          direction_id: 1,
+          start_date: "20171220",
+          start_time: "1:23:45",
+          schedule_relationship: :ADDED
+        },
+        stop_time_update: [%{}],
+        vehicle: %{
+          id: "vehicle_id"
+        }
+      }
+
+      [tu, _] = decode_trip_update(update, %Options{})
+
+      assert TripUpdate.start_time(tu) == "01:23:45"
+    end
+
+    test "can handle invalid start_time by treating it as nil" do
+      update = %{
+        trip: %{
+          trip_id: "trip",
+          route_id: "route",
+          direction_id: 1,
+          start_date: "20171220",
+          start_time: "12345",
+          schedule_relationship: :ADDED
+        },
+        stop_time_update: [%{}],
+        vehicle: %{
+          id: "vehicle_id"
+        }
+      }
+
+      [tu, _] = decode_trip_update(update, %Options{})
+
+      assert TripUpdate.start_time(tu) == nil
+    end
   end
 
   describe "decode_vehicle/2" do


### PR DESCRIPTION
One of our sources is returning invalid data in this field: validate that
it's correct and drop it if not.