### PR TITLE
refactor: increase the lookback time in TimeOutOfRange from one minute to 10 minutes

### DIFF
--- a/lib/concentrate/group_filter/time_out_of_range.ex
+++ b/lib/concentrate/group_filter/time_out_of_range.ex
@@ -5,8 +5,8 @@ defmodule Concentrate.GroupFilter.TimeOutOfRange do
   alias Concentrate.StopTimeUpdate
   @behaviour Concentrate.GroupFilter
 
-  # one minute
-  @min_time_in_past 60
+  # 10 minutes
+  @min_time_in_past 60 * 10
   # 3 hours
   @max_time_in_future 10_800
 

--- a/test/concentrate/group_filter/time_out_of_range_test.exs
+++ b/test/concentrate/group_filter/time_out_of_range_test.exs
@@ -5,12 +5,12 @@ defmodule Concentrate.GroupFilter.TimeOutOfRangeTest do
   alias Concentrate.StopTimeUpdate
 
   defp now do
-    100
+    1000
   end
 
   describe "filter/1" do
     test "removes StopTimeUpdates if they're in the past or future" do
-      stu = StopTimeUpdate.new(arrival_time: 100)
+      stu = StopTimeUpdate.new(arrival_time: 1000)
       assert {_, [], [^stu]} = filter({nil, [], [stu]}, &now/0)
 
       stu = StopTimeUpdate.new(departure_time: 10_000)
@@ -19,14 +19,17 @@ defmodule Concentrate.GroupFilter.TimeOutOfRangeTest do
       stu = StopTimeUpdate.new(arrival_time: 4)
       assert {_, [], []} = filter({nil, [], [stu]}, &now/0)
 
+      stu = StopTimeUpdate.new(arrival_time: 400)
+      assert {_, [], [^stu]} = filter({nil, [], [stu]}, &now/0)
+
       stu = StopTimeUpdate.new(arrival_time: 12_000)
       assert {_, [], []} = filter({nil, [], [stu]}, &now/0)
     end
 
     test "keeps stop time update if a previous update was in the range" do
       stus = [
-        StopTimeUpdate.new(arrival_time: 100),
-        StopTimeUpdate.new(arrival_time: 101)
+        StopTimeUpdate.new(arrival_time: 1000),
+        StopTimeUpdate.new(arrival_time: 120_000)
       ]
 
       group = {nil, [], stus}


### PR DESCRIPTION
Asana ticket: [increase allowed past time in TimeOutOfRange  GroupFilter](https://app.asana.com/0/584764604969369/1155876947667457/f)

Bumped up `@min_time_in_past` in `Concentrate.GroupFilter.TimeOutOfRange` from one minute to 10 minutes. Slightly modified assertions in `"removes StopTimeUpdates if they're in the past or future"` block to ensure we still cover all cases. Also changed  assertion in `"keeps stop time update if a previous update was in the range"` to more accurately match description. 