### PR TITLE
refactor: populate timestamp on TripUpdate using corresponding value in VehiclePosition

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,7 +37,8 @@ config :concentrate,
     Concentrate.GroupFilter.ClosedStop,
     Concentrate.GroupFilter.VehicleAtSkippedStop,
     Concentrate.GroupFilter.VehicleStopMatch,
-    Concentrate.GroupFilter.SkippedStopOnAddedTrip
+    Concentrate.GroupFilter.SkippedStopOnAddedTrip,
+    Concentrate.GroupFilter.TripUpdateTimestamp
   ],
   reporters: [
     Concentrate.Reporter.VehicleLatency,

--- a/lib/concentrate/encoder/gtfs_realtime_helpers.ex
+++ b/lib/concentrate/encoder/gtfs_realtime_helpers.ex
@@ -189,6 +189,8 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
       schedule_relationship: schedule_relationship(TripUpdate.schedule_relationship(update))
     }
 
+    timestamp = TripUpdate.timestamp(update)
+
     trip =
       trip_data
       |> Map.merge(enhanced_data_fn.(update))
@@ -211,7 +213,8 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
               drop_nil_values(%{
                 trip: trip,
                 stop_time_update: stop_time_update,
-                vehicle: vehicle
+                vehicle: vehicle,
+                timestamp: timestamp
               })
           }
         ]
@@ -220,7 +223,7 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
         [
           %{
             id: id,
-            trip_update: drop_nil_values(%{trip: trip, vehicle: vehicle})
+            trip_update: drop_nil_values(%{trip: trip, vehicle: vehicle, timestamp: timestamp})
           }
         ]
 

--- a/lib/concentrate/group_filter/trip_update_timestamp.ex
+++ b/lib/concentrate/group_filter/trip_update_timestamp.ex
@@ -1,0 +1,16 @@
+defmodule Concentrate.GroupFilter.TripUpdateTimestamp do
+  @moduledoc """
+  Populates timestamp in TripUpdate with corresponding timestamp in VehiclePosition
+  """
+  @behaviour Concentrate.GroupFilter
+  alias Concentrate.{TripUpdate, VehiclePosition}
+
+  @impl Concentrate.GroupFilter
+  def filter({%TripUpdate{timestamp: nil} = tu, [_ | _] = vps, stus}) do
+    timestamp = vps |> Enum.map(fn x -> VehiclePosition.last_updated(x) end) |> Enum.max()
+
+    {TripUpdate.update_timestamp(tu, timestamp), vps, stus}
+  end
+
+  def filter(other), do: other
+end

--- a/lib/concentrate/parser/gtfs_realtime.ex
+++ b/lib/concentrate/parser/gtfs_realtime.ex
@@ -126,7 +126,8 @@ defmodule Concentrate.Parser.GTFSRealtime do
         start_date: date(Map.get(trip, :start_date)),
         start_time: time(Map.get(trip, :start_time)),
         schedule_relationship: Map.get(trip, :schedule_relationship, :SCHEDULED),
-        vehicle_id: decode_trip_descriptor_vehicle_id(descriptor)
+        vehicle_id: decode_trip_descriptor_vehicle_id(descriptor),
+        timestamp: decode_trip_descriptor_timestamp(descriptor)
       )
     ]
   end
@@ -137,6 +138,9 @@ defmodule Concentrate.Parser.GTFSRealtime do
 
   defp decode_trip_descriptor_vehicle_id(%{vehicle: %{id: vehicle_id}}), do: vehicle_id
   defp decode_trip_descriptor_vehicle_id(_), do: nil
+
+  defp decode_trip_descriptor_timestamp(%{timestamp: timestamp}), do: timestamp
+  defp decode_trip_descriptor_timestamp(_), do: nil
 
   defp date(nil) do
     nil

--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -64,7 +64,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
   end
 
   def decode_trip_update(trip_update, options) do
-    tu = decode_trip_descriptor(Map.get(trip_update, "trip"))
+    tu = decode_trip_descriptor(trip_update)
     decode_stop_updates(tu, trip_update, options)
   end
 
@@ -121,7 +121,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
     position = Map.get(vp, "position", %{})
     vehicle = Map.get(vp, "vehicle", %{})
 
-    case decode_trip_descriptor(Map.get(vp, "trip")) do
+    case decode_trip_descriptor(vp) do
       [trip] ->
         [
           trip,
@@ -148,11 +148,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
     end
   end
 
-  defp decode_trip_descriptor(nil) do
-    []
-  end
-
-  defp decode_trip_descriptor(trip) do
+  defp decode_trip_descriptor(%{"trip" => trip} = descriptor) do
     [
       TripUpdate.new(
         trip_id: Map.get(trip, "trip_id"),
@@ -161,9 +157,14 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
         direction_id: Map.get(trip, "direction_id"),
         start_date: date(Map.get(trip, "start_date")),
         start_time: Map.get(trip, "start_time"),
-        schedule_relationship: schedule_relationship(Map.get(trip, "schedule_relationship"))
+        schedule_relationship: schedule_relationship(Map.get(trip, "schedule_relationship")),
+        timestamp: Map.get(descriptor, "timestamp")
       )
     ]
+  end
+
+  defp decode_trip_descriptor(_) do
+    []
   end
 
   defp decode_consist(nil) do

--- a/lib/concentrate/trip_update.ex
+++ b/lib/concentrate/trip_update.ex
@@ -12,6 +12,7 @@ defmodule Concentrate.TripUpdate do
     :start_date,
     :start_time,
     :vehicle_id,
+    :timestamp,
     schedule_relationship: :SCHEDULED
   ])
 

--- a/test/concentrate/encoder/trip_updates/json_test.exs
+++ b/test/concentrate/encoder/trip_updates/json_test.exs
@@ -8,7 +8,7 @@ defmodule Concentrate.Encoder.TripUpdates.JSONTest do
   describe "encode_groups/1" do
     test "same output as EncoderTripUpdates.encode_groups/1 but in JSON" do
       trip_updates = [
-        TripUpdate.new(trip_id: "1", schedule_relationship: :ADDED),
+        TripUpdate.new(trip_id: "1", schedule_relationship: :ADDED, timestamp: 1_534_340_406),
         TripUpdate.new(trip_id: "2"),
         TripUpdate.new(trip_id: "3")
       ]
@@ -34,6 +34,7 @@ defmodule Concentrate.Encoder.TripUpdates.JSONTest do
                %{
                  "id" => "1",
                  "trip_update" => %{
+                   "timestamp" => 1_534_340_406,
                    "stop_time_update" => [%{"schedule_relationship" => "SKIPPED"}],
                    "trip" => %{
                      "schedule_relationship" => "ADDED",

--- a/test/concentrate/encoder/trip_updates_enhanced_test.exs
+++ b/test/concentrate/encoder/trip_updates_enhanced_test.exs
@@ -106,5 +106,25 @@ defmodule Concentrate.Encoder.TripUpdatesEnhancedTest do
                ]
              } = encoded
     end
+
+    test "trips updates with timestamp present have that field" do
+      parsed = [
+        TripUpdate.new(trip_id: "trip", timestamp: 1_534_340_406),
+        StopTimeUpdate.new(trip_id: "trip", stop_id: "stop")
+      ]
+
+      encoded = Jason.decode!(encode_groups(group(parsed)))
+
+      assert %{
+               "entity" => [
+                 %{
+                   "trip_update" => %{
+                     "timestamp" => 1_534_340_406,
+                     "trip" => %{}
+                   }
+                 }
+               ]
+             } = encoded
+    end
   end
 end

--- a/test/concentrate/encoder/trip_updates_test.exs
+++ b/test/concentrate/encoder/trip_updates_test.exs
@@ -136,5 +136,22 @@ defmodule Concentrate.Encoder.TripUpdatesTest do
 
       refute "route_pattern_id" in Map.keys(trip)
     end
+
+    test "trips updates with timestamp present don't have that field" do
+      initial = [
+        TripUpdate.new(trip_id: "trip", timestamp: 1_534_340_406),
+        StopTimeUpdate.new(trip_id: "trip", stop_id: "stop", departure_time: 1)
+      ]
+
+      decoded = :gtfs_realtime_proto.decode_msg(encode_groups(group(initial)), :FeedMessage, [])
+
+      %{
+        entity: [
+          %{trip_update: %{trip: trip, timestamp: 1_534_340_406}}
+        ]
+      } = decoded
+
+      refute "route_pattern_id" in Map.keys(trip)
+    end
   end
 end

--- a/test/concentrate/group_filter/trip_update_timestamp_test.exs
+++ b/test/concentrate/group_filter/trip_update_timestamp_test.exs
@@ -1,0 +1,65 @@
+defmodule Concentrate.GroupFilter.TripUpdateTimestampTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  import Concentrate.GroupFilter.TripUpdateTimestamp
+  alias Concentrate.{TripUpdate, VehiclePosition}
+
+  describe "filter/1" do
+    test "populates timestamp in TripUpdate with corresponding timestamp in VehiclePosition" do
+      vp =
+        VehiclePosition.new(
+          trip_id: "trip",
+          latitude: 1,
+          longitude: 1,
+          last_updated: 1_514_558_974
+        )
+
+      tu = TripUpdate.new([])
+
+      assert {%{tu | timestamp: VehiclePosition.last_updated(vp)}, [vp], []} ==
+               filter({tu, [vp], []})
+    end
+
+    test "use VehiclePostition with max timestamp if more than one is present" do
+      vp1 =
+        VehiclePosition.new(
+          trip_id: "trip",
+          latitude: 1,
+          longitude: 1,
+          last_updated: 1_514_558_974
+        )
+
+      vp2 =
+        VehiclePosition.new(
+          trip_id: "trip",
+          latitude: 1,
+          longitude: 1,
+          last_updated: 1_514_558_975
+        )
+
+      tu = TripUpdate.new([])
+
+      assert {%{tu | timestamp: VehiclePosition.last_updated(vp2)}, [vp1, vp2], []} ==
+               filter({tu, [vp1, vp2], []})
+    end
+
+    test "uses timestamp on TripUpdate if one exists" do
+      vp =
+        VehiclePosition.new(
+          trip_id: "trip",
+          latitude: 1,
+          longitude: 1,
+          last_updated: 1_514_558_974
+        )
+
+      tu = TripUpdate.new(timestamp: 1_514_558_900)
+
+      assert {tu, [vp], []} ==
+               filter({tu, [vp], []})
+    end
+
+    test "other values are returned as-is" do
+      assert filter(:value) == :value
+    end
+  end
+end

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -234,6 +234,20 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
       [tu] = decode_trip_update(map, Helpers.parse_options([]))
       assert TripUpdate.route_pattern_id(tu) == "pattern"
     end
+
+    test "includes timestamp if available" do
+      map = %{
+        "trip" => %{
+          "trip_id" => "trip",
+          "route_id" => "route"
+        },
+        "timestamp" => 1_534_340_406,
+        "stop_time_update" => []
+      }
+
+      [tu] = decode_trip_update(map, Helpers.parse_options([]))
+      assert TripUpdate.timestamp(tu) == 1_534_340_406
+    end
   end
 
   describe "decode_vehicle/1" do
@@ -279,7 +293,8 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
                  route_id: "Green-E",
                  direction_id: 0,
                  start_date: {2018, 8, 15},
-                 schedule_relationship: :SCHEDULED
+                 schedule_relationship: :SCHEDULED,
+                 timestamp: 1_534_340_406
                )
 
       assert vp ==

--- a/test/concentrate/parser/gtfs_realtime_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_test.exs
@@ -59,6 +59,7 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
           start_time: "26:15:09",
           schedule_relationship: :ADDED
         },
+        timestamp: 1_534_340_406,
         stop_time_update: [%{}],
         vehicle: %{
           id: "vehicle_id"
@@ -75,7 +76,8 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
                  start_date: {2017, 12, 20},
                  start_time: "26:15:09",
                  vehicle_id: "vehicle_id",
-                 schedule_relationship: :ADDED
+                 schedule_relationship: :ADDED,
+                 timestamp: 1_534_340_406
                )
     end
 
@@ -292,6 +294,18 @@ defmodule Concentrate.Parser.GTFSRealtimeTest do
       }
 
       assert [_, _] = decode_vehicle(position, %Options{routes: {:ok, ["keeping"]}})
+    end
+
+    test "includes timestamp if available" do
+      position = %{
+        timestamp: 1_534_340_406,
+        trip: %{route_id: "keeping"},
+        vehicle: %{},
+        position: %{latitude: 1, longitude: 1}
+      }
+
+      assert [tu, _] = decode_vehicle(position, %Options{routes: {:ok, ["keeping"]}})
+      assert TripUpdate.timestamp(tu) == 1_534_340_406
     end
   end
 end


### PR DESCRIPTION
Asana ticket: [populate timestamp in TripUpdates.pb if there's a corresponding timestamp for the Vehicle](https://app.asana.com/0/584764604969369/1150546384019615)

Changes:
* Updated relevant `parsers` to use `timestamp` on `TripUpdate` if it exists
* Added `Concentrate.GroupFilter.TripUpdateTimestamp` to use the timestamp from corresponding `VehiclePosition`
* Updated `encoders` to use the `timestamp` value on a `TripUpdate`