### PR TITLE
fix: update build steps for Distillery 2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,13 @@ RUN apk --update add git make
 
 ENV MIX_ENV=prod
 
+ADD mix.* /root/
+
+RUN elixir --erl "-smp enable" /usr/local/bin/mix do deps.get --only prod, deps.compile
+
 ADD . .
 
-WORKDIR /root
-
-RUN elixir --erl "-smp enable" /usr/local/bin/mix do deps.get --only prod, compile, release --verbose
+RUN elixir --erl "-smp enable" /usr/local/bin/mix do compile, distillery.release --verbose
 
 # Second stage: uses the built .tgz to get the files over
 FROM alpine:3.8

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -7,7 +7,7 @@
 |> Path.wildcard()
 |> Enum.map(&Code.eval_file(&1))
 
-use Mix.Releases.Config,
+use Distillery.Releases.Config,
     # This sets the default release built by `mix release`
     default_release: :default,
     # This sets the default environment used by `mix release`


### PR DESCRIPTION
- name of the Mix task is `distillery.release`
- name of the config provider is `Distillery.Releases.Config`