### PR TITLE
fix: explicitly specify which directories to copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,10 @@ ADD mix.* /root/
 
 RUN elixir --erl "-smp enable" /usr/local/bin/mix do deps.get --only prod, deps.compile
 
-ADD . .
+ADD lib /root/lib
+ADD src /root/src
+ADD config /root/config
+ADD rel /root/rel
 
 RUN elixir --erl "-smp enable" /usr/local/bin/mix do compile, distillery.release --verbose
 


### PR DESCRIPTION
It looks like CI is also re-copying the mix.exs and mix.lock files, which is
confusing the build step.