### PR TITLE
fix(GTFSRealtimeEnhanced): parse the `vehicle_id` for TripUpdate

### DIFF
--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -149,6 +149,12 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
   end
 
   defp decode_trip_descriptor(%{"trip" => trip} = descriptor) do
+    vehicle_id =
+      case descriptor do
+        %{"vehicle" => %{"id" => vehicle_id}} -> vehicle_id
+        _ -> nil
+      end
+
     [
       TripUpdate.new(
         trip_id: Map.get(trip, "trip_id"),
@@ -158,7 +164,8 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
         start_date: date(Map.get(trip, "start_date")),
         start_time: Map.get(trip, "start_time"),
         schedule_relationship: schedule_relationship(Map.get(trip, "schedule_relationship")),
-        timestamp: Map.get(descriptor, "timestamp")
+        timestamp: Map.get(descriptor, "timestamp"),
+        vehicle_id: vehicle_id
       )
     ]
   end

--- a/test/concentrate/encoder/vehicle_positions_enhanced_test.exs
+++ b/test/concentrate/encoder/vehicle_positions_enhanced_test.exs
@@ -10,9 +10,9 @@ defmodule Concentrate.Encoder.VehiclePositionsEnhancedTest do
   describe "encode/1" do
     test "includes consist data if present" do
       data = [
-        TripUpdate.new(trip_id: "one"),
+        TripUpdate.new(trip_id: "one", vehicle_id: "y1"),
         VehiclePosition.new(trip_id: "one", id: "y1", latitude: 1, longitude: 1),
-        TripUpdate.new(trip_id: "two"),
+        TripUpdate.new(trip_id: "two", vehicle_id: "y2"),
         VehiclePosition.new(
           trip_id: "two",
           id: "y2",

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -248,6 +248,22 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
       [tu] = decode_trip_update(map, Helpers.parse_options([]))
       assert TripUpdate.timestamp(tu) == 1_534_340_406
     end
+
+    test "includes vehicle_id if available" do
+      map = %{
+        "trip" => %{
+          "trip_id" => "trip",
+          "route_id" => "route"
+        },
+        "vehicle" => %{
+          "id" => "vehicle_id"
+        },
+        "stop_time_update" => []
+      }
+
+      [tu] = decode_trip_update(map, Helpers.parse_options([]))
+      assert TripUpdate.vehicle_id(tu) == "vehicle_id"
+    end
   end
 
   describe "decode_vehicle/1" do
@@ -294,7 +310,8 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
                  direction_id: 0,
                  start_date: {2018, 8, 15},
                  schedule_relationship: :SCHEDULED,
-                 timestamp: 1_534_340_406
+                 timestamp: 1_534_340_406,
+                 vehicle_id: "G-10098"
                )
 
       assert vp ==


### PR DESCRIPTION
We parsed this out of Protobuf TripUpdates, but not for the enhanced
feeds. This means we were dropping that information for our subway feeds,
which are now enhanced.