### PR TITLE
two patches: disable vehiclepaststop and sort trip updates

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,6 @@ config :concentrate,
   group_filters: [
     Concentrate.GroupFilter.TimeOutOfRange,
     Concentrate.GroupFilter.RemoveUnneededTimes,
-    Concentrate.GroupFilter.VehiclePastStop,
     Concentrate.GroupFilter.Shuttle,
     Concentrate.GroupFilter.SkippedDepartures,
     Concentrate.GroupFilter.CancelledTrip,

--- a/lib/concentrate/trip_update.ex
+++ b/lib/concentrate/trip_update.ex
@@ -25,6 +25,14 @@ defmodule Concentrate.TripUpdate do
     def key(%{trip_id: trip_id}), do: trip_id
 
     def merge(first, second) do
+      if {first.start_date, first.start_time} > {second.start_date, second.start_time} do
+        do_merge(first, second)
+      else
+        do_merge(second, first)
+      end
+    end
+
+    def do_merge(first, second) do
       %{
         first
         | route_id: first.route_id || second.route_id,

--- a/test/concentrate/trip_update_test.exs
+++ b/test/concentrate/trip_update_test.exs
@@ -11,14 +11,14 @@ defmodule Concentrate.TripUpdateTest do
           trip_id: "trip",
           route_id: "route",
           route_pattern_id: "pattern",
-          start_date: ~D[2017-12-20]
+          start_date: {2017, 12, 20}
         )
 
       second =
         new(
           trip_id: "trip",
           direction_id: 0,
-          start_time: ~T[12:00:00],
+          start_time: "12:00:00",
           schedule_relationship: :ADDED
         )
 
@@ -28,9 +28,36 @@ defmodule Concentrate.TripUpdateTest do
           route_id: "route",
           route_pattern_id: "pattern",
           direction_id: 0,
-          start_date: ~D[2017-12-20],
-          start_time: ~T[12:00:00],
+          start_date: {2017, 12, 20},
+          start_time: "12:00:00",
           schedule_relationship: :ADDED
+        )
+
+      assert Mergeable.merge(first, second) == expected
+      assert Mergeable.merge(second, first) == expected
+    end
+
+    test "merge/2 prefers the later start date/time" do
+      first =
+        new(
+          route_id: "route",
+          start_date: {2020, 4, 14},
+          start_time: "05:05:05"
+        )
+
+      second =
+        new(
+          route_pattern_id: "pattern",
+          start_date: {2020, 4, 15},
+          start_time: "05:05:04"
+        )
+
+      expected =
+        new(
+          route_id: "route",
+          route_pattern_id: "pattern",
+          start_date: {2020, 4, 15},
+          start_time: "05:05:04"
         )
 
       assert Mergeable.merge(first, second) == expected


### PR DESCRIPTION
- disable the VehiclePastStop filter so we don't drop StopTimeUpdates earlier than the schedule
- sort TripUpdates by start_date/time to (hopefull) work around a vendor issue