### PR TITLE
Log vehicle timestamp mismatch

### DIFF
--- a/lib/concentrate/parser/helpers.ex
+++ b/lib/concentrate/parser/helpers.ex
@@ -10,9 +10,14 @@ defmodule Concentrate.Parser.Helpers do
             routes: :all | {:ok, MapSet.t()},
             excluded_routes: :none | {:ok, MapSet.t()},
             max_time: :infinity | non_neg_integer,
-            drop_fields: drop_fields
+            drop_fields: drop_fields,
+            feed_url: String.t() | nil
           }
-    defstruct routes: :all, excluded_routes: :none, max_time: :infinity, drop_fields: %{}
+    defstruct routes: :all,
+              excluded_routes: :none,
+              max_time: :infinity,
+              drop_fields: %{},
+              feed_url: nil
   end
 
   alias __MODULE__.Options
@@ -51,6 +56,10 @@ defmodule Concentrate.Parser.Helpers do
   defp parse_options([{:max_future_time, seconds} | rest], acc) do
     max_time = :os.system_time(:seconds) + seconds
     parse_options(rest, %{acc | max_time: max_time})
+  end
+
+  defp parse_options([{:feed_url, url} | rest], acc) do
+    parse_options(rest, %{acc | feed_url: url})
   end
 
   defp parse_options([_ | rest], acc) do

--- a/lib/concentrate/producer/httpoison.ex
+++ b/lib/concentrate/producer/httpoison.ex
@@ -27,10 +27,10 @@ defmodule Concentrate.Producer.HTTPoison do
     parser =
       case Keyword.fetch!(opts, :parser) do
         module when is_atom(module) ->
-          &module.parse(&1, [])
+          &module.parse(&1, feed_url: url)
 
         {module, opts} when is_atom(module) and is_list(opts) ->
-          &module.parse(&1, opts)
+          &module.parse(&1, [feed_url: url] ++ opts)
 
         fun when is_function(fun, 1) ->
           fun

--- a/test/concentrate/parser/helpers_test.exs
+++ b/test/concentrate/parser/helpers_test.exs
@@ -24,4 +24,11 @@ defmodule Concentrate.Parser.HelpersTest do
       assert VehiclePosition.speed(new_vp) == nil
     end
   end
+
+  describe "parse_options/1" do
+    test "handles feed_url option" do
+      assert %Concentrate.Parser.Helpers.Options{feed_url: "url"} =
+               Concentrate.Parser.Helpers.parse_options(feed_url: "url")
+    end
+  end
 end


### PR DESCRIPTION
Asana ticket: [🚝 log vehicle timestamps which are greater than the reported feed timestamp](https://app.asana.com/0/584764604969369/1168026177896885/f)