### PR TITLE
support routes/excluded_routes when parsing enhanced VehiclePositions

### DIFF
--- a/lib/concentrate/parser/gtfs_realtime.ex
+++ b/lib/concentrate/parser/gtfs_realtime.ex
@@ -56,13 +56,7 @@ defmodule Concentrate.Parser.GTFSRealtime do
       id = Map.get(vehicle, :id)
       timestamp = Map.get(vp, :timestamp)
 
-      if is_integer(timestamp) && is_integer(feed_timestamp) && timestamp > feed_timestamp do
-        Logger.warn(
-          "vehicle timestamp after feed timestamp feed_url=#{inspect(options.feed_url)} vehicle_id=#{
-            inspect(id)
-          } feed_timestamp=#{inspect(feed_timestamp)} vehicle_timestamp=#{inspect(timestamp)}"
-        )
-      end
+      Helpers.log_future_vehicle_timestamp(options, feed_timestamp, timestamp, id)
 
       tu ++
         [

--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -44,7 +44,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
   end
 
   defp decode_feed_entity(%{"vehicle" => %{} = vehicle}, options, feed_timestamp) do
-    decode_vehicle(vehicle, options.feed_url, feed_timestamp)
+    decode_vehicle(vehicle, options, feed_timestamp)
   end
 
   defp decode_feed_entity(%{"id" => id, "alert" => %{} = alert}, _options, _feed_timestamp) do
@@ -121,20 +121,14 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
     end
   end
 
-  @spec decode_vehicle(map(), String.t() | nil, integer | nil) :: [any()]
-  def decode_vehicle(vp, feed_url, feed_timestamp) do
+  @spec decode_vehicle(map(), Helpers.Options.t(), integer | nil) :: [any()]
+  def decode_vehicle(vp, options, feed_timestamp) do
     position = Map.get(vp, "position", %{})
     vehicle = Map.get(vp, "vehicle", %{})
     id = Map.get(vehicle, "id")
     timestamp = Map.get(vp, "timestamp")
 
-    if is_integer(timestamp) && is_integer(feed_timestamp) && timestamp > feed_timestamp do
-      Logger.warn(
-        "vehicle timestamp after feed timestamp feed_url=#{inspect(feed_url)} vehicle_id=#{
-          inspect(id)
-        } feed_timestamp=#{inspect(feed_timestamp)} vehicle_timestamp=#{inspect(timestamp)}"
-      )
-    end
+    Helpers.log_future_vehicle_timestamp(options, feed_timestamp, timestamp, id)
 
     case decode_trip_descriptor(vp) do
       [trip] ->

--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -132,27 +132,31 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
 
     case decode_trip_descriptor(vp) do
       [trip] ->
-        [
-          trip,
-          VehiclePosition.new(
-            id: id,
-            trip_id: TripUpdate.trip_id(trip),
-            stop_id: Map.get(vp, "stop_id"),
-            label: Map.get(vehicle, "label"),
-            license_plate: Map.get(vehicle, "license_plate"),
-            latitude: Map.get(position, "latitude"),
-            longitude: Map.get(position, "longitude"),
-            bearing: Map.get(position, "bearing"),
-            speed: Map.get(position, "speed"),
-            odometer: Map.get(position, "odometer"),
-            status: vehicle_status(Map.get(vp, "current_status")),
-            stop_sequence: Map.get(vp, "current_stop_sequence"),
-            last_updated: timestamp,
-            consist: decode_consist(Map.get(vehicle, "consist")),
-            occupancy_status: occupancy_status(Map.get(vp, "occupancy_status")),
-            occupancy_percentage: Map.get(vp, "occupancy_percentage")
-          )
-        ]
+        if Helpers.valid_route_id?(options, TripUpdate.route_id(trip)) do
+          [
+            trip,
+            VehiclePosition.new(
+              id: id,
+              trip_id: TripUpdate.trip_id(trip),
+              stop_id: Map.get(vp, "stop_id"),
+              label: Map.get(vehicle, "label"),
+              license_plate: Map.get(vehicle, "license_plate"),
+              latitude: Map.get(position, "latitude"),
+              longitude: Map.get(position, "longitude"),
+              bearing: Map.get(position, "bearing"),
+              speed: Map.get(position, "speed"),
+              odometer: Map.get(position, "odometer"),
+              status: vehicle_status(Map.get(vp, "current_status")),
+              stop_sequence: Map.get(vp, "current_stop_sequence"),
+              last_updated: timestamp,
+              consist: decode_consist(Map.get(vehicle, "consist")),
+              occupancy_status: occupancy_status(Map.get(vp, "occupancy_status")),
+              occupancy_percentage: Map.get(vp, "occupancy_percentage")
+            )
+          ]
+        else
+          []
+        end
 
       [] ->
         []

--- a/lib/concentrate/parser/helpers.ex
+++ b/lib/concentrate/parser/helpers.ex
@@ -2,6 +2,7 @@ defmodule Concentrate.Parser.Helpers do
   @moduledoc """
   Helper functions for the GTFS-RT and GTFS-RT Enhanced parsers.
   """
+  require Logger
 
   defmodule Options do
     @moduledoc false
@@ -123,4 +124,34 @@ defmodule Concentrate.Parser.Helpers do
   def times_less_than_max?(nil, nil, _), do: true
   def times_less_than_max?(time, nil, max), do: time <= max
   def times_less_than_max?(_, time, max), do: time <= max
+
+  @doc """
+  Log a warning if the vehicle timestamp is greater than the feed timestamp.
+  """
+  @spec log_future_vehicle_timestamp(
+          Options.t(),
+          non_neg_integer | nil,
+          non_neg_integer | nil,
+          String.t()
+        ) :: :ok
+  def log_future_vehicle_timestamp(options, feed_timestamp, vehicle_timestamp, vehicle_id)
+
+  def log_future_vehicle_timestamp(options, feed_timestamp, vehicle_timestamp, vehicle_id)
+      when is_integer(vehicle_timestamp) and is_integer(feed_timestamp) and
+             vehicle_timestamp > feed_timestamp do
+    _ =
+      Logger.warn(
+        "vehicle timestamp after feed timestamp feed_url=#{inspect(options.feed_url)} vehicle_id=#{
+          inspect(vehicle_id)
+        } feed_timestamp=#{inspect(feed_timestamp)} vehicle_timestamp=#{
+          inspect(vehicle_timestamp)
+        }"
+      )
+
+    :ok
+  end
+
+  def log_future_vehicle_timestamp(_options, _feed_timestamp, _vehicle_timestamp, _vehicle_id) do
+    :ok
+  end
 end

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -269,7 +269,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
 
   describe "decode_vehicle/3" do
     test "returns nothing if there's an empty map" do
-      assert decode_vehicle(%{}, nil, nil) == []
+      assert decode_vehicle(%{}, Helpers.parse_options([]), nil) == []
     end
 
     test "decodes a VehiclePosition JSON map" do
@@ -303,7 +303,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
         }
       }
 
-      assert [tu, vp] = decode_vehicle(map, nil, nil)
+      assert [tu, vp] = decode_vehicle(map, Helpers.parse_options([]), nil)
 
       assert tu ==
                TripUpdate.new(
@@ -360,7 +360,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
         }
       }
 
-      assert [_tu, vp] = decode_vehicle(map, nil, nil)
+      assert [_tu, vp] = decode_vehicle(map, Helpers.parse_options([]), nil)
 
       assert VehiclePosition.consist(vp) == [
                VehiclePosition.Consist.new(label: "3823"),
@@ -395,7 +395,10 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
         }
       }
 
-      log = capture_log([level: :warn], fn -> decode_vehicle(map, "test_url", 1_534_340_306) end)
+      log =
+        capture_log([level: :warn], fn ->
+          decode_vehicle(map, Helpers.parse_options(feed_url: "test_url"), 1_534_340_306)
+        end)
 
       assert log =~ "vehicle timestamp after feed timestamp"
     end

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -272,6 +272,20 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
       assert decode_vehicle(%{}, Helpers.parse_options([]), nil) == []
     end
 
+    test "drops the VehiclePosition if the route is ignored" do
+      map = %{
+        "trip" => %{"route_id" => "route"},
+        "position" => %{
+          "latitude" => 1.0,
+          "longitude" => 1.0
+        }
+      }
+
+      assert [_, _] = decode_vehicle(map, Helpers.parse_options([]), nil)
+      assert [_, _] = decode_vehicle(map, Helpers.parse_options(routes: ["route"]), nil)
+      assert [] = decode_vehicle(map, Helpers.parse_options(excluded_routes: ["route"]), nil)
+    end
+
     test "decodes a VehiclePosition JSON map" do
       map = %{
         "congestion_level" => nil,


### PR DESCRIPTION
The normal VehiclePositions already supported this, but not the enhanced parser.