### PR TITLE
ci: report code coverage as a `workflow_run` step

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,6 +1,6 @@
 name: Elixir CI
 
-on: [push, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -36,11 +36,10 @@ jobs:
     - name: Run tests
       run: mix test --cover
     - name: Upload coverage artifact
-      uses: zgosalvez/github-actions-report-lcov@v1
+      uses: actions/upload-artifact@v2
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        coverage-files: ./coverage/lcov*.info
-        artifact-name: elixir-code-coverage
+        name: elixir-lcov
+        path: coverage/
     - name: Restore Dialyzer cache
       id: dialyzer-cache
       uses: actions/cache@v2

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -46,9 +46,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: _build/dev/dialyxir*.plt*
-        key: ${{ runner.os }}-dialyxir-${{ steps.elixir.otp-version }}-${{ steps.elixir.elixir_version }}-${{ hashFiles('**/mix.lock') }}
+        key: ${{ runner.os }}-dialyxir-${{ steps.elixir.outputs.otp-version }}-${{ steps.elixir.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          ${{ runner.os }}-dialyxir-${{ steps.elixir.otp-version }}-${{ steps.elixir.elixir_version }}-
-          ${{ runner.os }}-dialyxir-${{ steps.elixir.otp-version }}-
+          ${{ runner.os }}-dialyxir-${{ steps.elixir.outputs.otp-version }}-${{ steps.elixir.outputs.elixir-version }}-
+          ${{ runner.os }}-dialyxir-${{ steps.elixir.outputs.otp-version }}-
     - name: Dialyzer
       run: mix dialyzer --halt-exit-status

--- a/.github/workflows/report_coverage.yml
+++ b/.github/workflows/report_coverage.yml
@@ -1,0 +1,49 @@
+name: Report coverage
+
+on:
+  workflow_run:
+    workflows:
+      - Elixir CI
+    types:
+      - completed
+
+jobs:
+  report-coverage:
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - run: echo Fetching artifacts for ${{ github.event.workflow_run.id }}, event name ${{ github.event_name }}, triggered by ${{ github.event.workflow_run.event }}
+    - run: echo Should have run? ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+
+    - uses: actions/checkout@v2 # UNTRUSTED CODE - do not run scripts from it
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Download artifact
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          var artifacts = await github.actions.listWorkflowRunArtifacts({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: ${{github.event.workflow_run.id }},
+          });
+          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "elixir-lcov"
+          })[0];
+          var download = await github.actions.downloadArtifact({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            artifact_id: matchArtifact.id,
+            archive_format: 'zip',
+          });
+          var fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/elixir-lcov.zip', Buffer.from(download.data));
+    - run: unzip elixir-lcov.zip
+    - run: ls
+    - name: Upload coverage artifact and post comment
+      uses: mbta/github-actions-report-lcov@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        coverage-files: ./lcov*.info
+        artifact-name: elixir-code-coverage


### PR DESCRIPTION
Since this doesn't run any untrusted code, it has a GITHUB_TOKEN with permission to post to the repository. You can see the example working in my fork with this PR: https://github.com/paulswartz/concentrate/pull/4

The `pull_request_target` failure is known, and also happening on the `master` branch. The `pull_request` GitHub Action is the correct once.