### PR TITLE
ci: use ASDF to install Elixir/Erlang

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -61,30 +61,4 @@ jobs:
       with:
         name: elixir-lcov
         path: coverage/
-    - name: Set Dialyzer Cache Keys
-      run: |
-        cat <<EOF > ${{ runner.temp }}/cache_keys.exs
-        architecture = :erlang.system_info(:system_architecture)
-        action = "dialyzer"
-        cache_key = Enum.intersperse([architecture, action, System.otp_release(), System.version()], ?-)
-        otp_prefix = Enum.intersperse([architecture, action, System.otp_release()], ?-)
-        system_prefix = Enum.intersperse([architecture, action], ?-)
-        IO.puts(['::set-output name=CACHE_KEY::', cache_key])
-        IO.puts(['::set-output name=OTP_PREFIX::', otp_prefix])
-        IO.puts(['::set-output name=SYSTEM_PREFIX::', system_prefix])
-        EOF
-        elixir -r ${{ runner.temp }}/cache_keys.exs
-        rm -f ${{ runner.temp }}/cache_keys.exs
-      id: dialyzer-keys
-    - name: Restore Dialyzer cache
-      id: dialyzer-cache
-      uses: actions/cache@v2
-      with:
-        path: _build/dev/dialyxir*.plt*
-        key: ${{ steps.dialyzer-keys.outputs.CACHE_KEY }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: |
-          ${{ steps.dialyzer-keys.outputs.CACHE_KEY }}-
-          ${{ steps.dialyzer-keys.outputs.OTP_PREFIX }}-
-          ${{ steps.dialyzer-keys.outputs.SYSTEM_PREFIX }}-
-    - name: Dialyzer
-      run: mix dialyzer --halt-exit-status
+    - uses: mbta/actions/dialyzer@v1

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,12 +10,27 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Elixir
-      id: elixir
-      uses: erlef/setup-beam@v1
+    # cache the ASDF directory, using the values from .tool-versions
+    - name: ASDF cache
+      uses: actions/cache@v2
       with:
-        elixir-version: '1.10.3' # Define the elixir version [required]
-        otp-version: '23.0.2' # Define the OTP version [required]
+        path: ~/.asdf
+        key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
+      id: asdf-cache
+    # only run `asdf install` if we didn't hit the cache
+    - uses: asdf-vm/actions/install@v1
+      if: steps.asdf-cache.outputs.cache-hit != 'true'
+    # if we did hit the cache, set up the environment
+    - name: Setup ASDF environment
+      run: |
+        echo "ASDF_DIR=$HOME/.asdf" >> $GITHUB_ENV
+        echo "ASDF_DATA_DIR=$HOME/.asdf" >> $GITHUB_ENV
+      if: steps.asdf-cache.outputs.cache-hit == 'true'
+    - name: Reshim ASDF
+      run: |
+        echo "$ASDF_DIR/bin" >> $GITHUB_PATH
+        echo "$ASDF_DIR/shims" >> $GITHUB_PATH
+        $ASDF_DIR/bin/asdf reshim
     - name: Restore dependencies cache
       id: deps-cache
       uses: actions/cache@v2
@@ -24,15 +39,16 @@ jobs:
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
     - name: Install dependencies
-      run: mix deps.get
+      run: |
+        mix local.rebar --foce
+        mix local.hex --force
+        mix deps.get
+    - name: Compile (warnings as errors)
+      run: mix compile --force --warnings-as-errors
     - name: Check formatting
       run: mix format --check-formatted
     - name: Credo
       run: mix credo --strict
-    - name: Compile (warnings as errors)
-      env:
-        MIX_ENV: test
-      run: mix compile --force --warnings-as-errors
     - name: Run tests
       run: mix test --cover
     - name: Save PR information
@@ -45,14 +61,30 @@ jobs:
       with:
         name: elixir-lcov
         path: coverage/
+    - name: Set Dialyzer Cache Keys
+      run: |
+        cat <<EOF > ${{ runner.temp }}/cache_keys.exs
+        architecture = :erlang.system_info(:system_architecture)
+        action = "dialyzer"
+        cache_key = Enum.intersperse([architecture, action, System.otp_release(), System.version()], ?-)
+        otp_prefix = Enum.intersperse([architecture, action, System.otp_release()], ?-)
+        system_prefix = Enum.intersperse([architecture, action], ?-)
+        IO.puts(['::set-output name=CACHE_KEY::', cache_key])
+        IO.puts(['::set-output name=OTP_PREFIX::', otp_prefix])
+        IO.puts(['::set-output name=SYSTEM_PREFIX::', system_prefix])
+        EOF
+        elixir -r ${{ runner.temp }}/cache_keys.exs
+        rm -f ${{ runner.temp }}/cache_keys.exs
+      id: dialyzer-keys
     - name: Restore Dialyzer cache
       id: dialyzer-cache
       uses: actions/cache@v2
       with:
         path: _build/dev/dialyxir*.plt*
-        key: ${{ runner.os }}-dialyxir-${{ steps.elixir.outputs.otp-version }}-${{ steps.elixir.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        key: ${{ steps.dialyzer-keys.outputs.CACHE_KEY }}-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          ${{ runner.os }}-dialyxir-${{ steps.elixir.outputs.otp-version }}-${{ steps.elixir.outputs.elixir-version }}-
-          ${{ runner.os }}-dialyxir-${{ steps.elixir.outputs.otp-version }}-
+          ${{ steps.dialyzer-keys.outputs.CACHE_KEY }}-
+          ${{ steps.dialyzer-keys.outputs.OTP_PREFIX }}-
+          ${{ steps.dialyzer-keys.outputs.SYSTEM_PREFIX }}-
     - name: Dialyzer
       run: mix dialyzer --halt-exit-status

--- a/.github/workflows/report_coverage.yml
+++ b/.github/workflows/report_coverage.yml
@@ -7,6 +7,9 @@ on:
     types:
       - completed
 
+permissions:
+  pull-requests: write
+
 jobs:
   report-coverage:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
This lets us use the single `.tool-versions` configuration for installation, rather than needing to maintain the current version in multiple places. Caching the builds is slow the first time, but quick in future runs.