### PR TITLE
fix: require `stop_sequence` for StopTimeUpdates

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -25,7 +25,8 @@ config :concentrate,
   filters: [
     Concentrate.Filter.VehicleWithNoTrip,
     Concentrate.Filter.RoundSpeedAndBearing,
-    Concentrate.Filter.IncludeRouteDirection
+    Concentrate.Filter.IncludeRouteDirection,
+    Concentrate.Filter.IncludeStopID
   ],
   group_filters: [
     Concentrate.GroupFilter.TimeOutOfRange,

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,6 +23,7 @@ config :concentrate,
     url: "https://cdn.mbta.com/MBTA_GTFS.zip"
   ],
   filters: [
+    Concentrate.Filter.NullStopSequence,
     Concentrate.Filter.VehicleWithNoTrip,
     Concentrate.Filter.RoundSpeedAndBearing,
     Concentrate.Filter.IncludeRouteDirection,

--- a/lib/concentrate/filter/gtfs/helpers.ex
+++ b/lib/concentrate/filter/gtfs/helpers.ex
@@ -1,0 +1,23 @@
+defmodule Concentrate.Filter.GTFS.Helpers do
+  @moduledoc "Shared helpers for `Filter.GTFS` modules."
+
+  @doc "Turns the given binary into a Stream of lines."
+  @spec io_stream(binary) :: Enumerable.t()
+  def io_stream(body) when is_binary(body) do
+    Stream.resource(
+      fn ->
+        {:ok, pid} = StringIO.open(body)
+        pid
+      end,
+      fn pid ->
+        case IO.read(pid, :line) do
+          line when is_binary(line) -> {[line], pid}
+          _ -> {:halt, pid}
+        end
+      end,
+      fn pid ->
+        StringIO.close(pid)
+      end
+    )
+  end
+end

--- a/lib/concentrate/filter/gtfs/pickup_drop_off.ex
+++ b/lib/concentrate/filter/gtfs/pickup_drop_off.ex
@@ -3,6 +3,7 @@ defmodule Concentrate.Filter.GTFS.PickupDropOff do
   Server which knows whether riders can be picked up or dropped off at a stop.
   """
   use GenStage
+  alias Concentrate.Filter.GTFS.Helpers
   require Logger
   import :binary, only: [copy: 1]
   @table __MODULE__
@@ -38,7 +39,7 @@ defmodule Concentrate.Filter.GTFS.PickupDropOff do
       |> List.flatten()
       |> Stream.flat_map(fn
         {"stop_times.txt", body} ->
-          io_stream(body)
+          Helpers.io_stream(body)
 
         _ ->
           []
@@ -62,26 +63,6 @@ defmodule Concentrate.Filter.GTFS.PickupDropOff do
       end
 
     {:noreply, [], state, :hibernate}
-  end
-
-  @spec io_stream(binary) :: Enumerable.t()
-  defp io_stream(body) when is_binary(body) do
-    # turns the given binary into a Stream of lines.
-    Stream.resource(
-      fn ->
-        {:ok, pid} = StringIO.open(body)
-        pid
-      end,
-      fn pid ->
-        case IO.read(pid, :line) do
-          line when is_binary(line) -> {[line], pid}
-          _ -> {:halt, pid}
-        end
-      end,
-      fn pid ->
-        StringIO.close(pid)
-      end
-    )
   end
 
   defp can_pickup_drop_off?("1"), do: false

--- a/lib/concentrate/filter/gtfs/stop_ids.ex
+++ b/lib/concentrate/filter/gtfs/stop_ids.ex
@@ -1,0 +1,65 @@
+defmodule Concentrate.Filter.GTFS.StopIDs do
+  @moduledoc """
+  Server which knows the stop ID for a given trip ID and stop sequence.
+  """
+  use GenStage
+  alias Concentrate.Filter.GTFS.Helpers
+  require Logger
+  import :binary, only: [copy: 1]
+  @table __MODULE__
+
+  def start_link(opts) do
+    GenStage.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @spec stop_id(String.t(), non_neg_integer) :: String.t() | :unknown
+  def stop_id(trip_id, stop_sequence) do
+    case :ets.lookup(@table, {trip_id, stop_sequence}) do
+      [{_, value}] -> value
+      [] -> :unknown
+    end
+  rescue
+    ArgumentError -> :unknown
+  end
+
+  @impl GenStage
+  def init(opts) do
+    @table = :ets.new(@table, [:named_table, :public, :set])
+    {:consumer, [], opts}
+  end
+
+  @impl GenStage
+  def handle_events(events, _from, state) do
+    inserts =
+      events
+      |> List.flatten()
+      |> Stream.flat_map(fn
+        {"stop_times.txt", body} ->
+          Helpers.io_stream(body)
+
+        _ ->
+          []
+      end)
+      |> CSV.decode(headers: true, num_workers: System.schedulers())
+      |> Enum.map(&build_insert/1)
+
+    if inserts != [] do
+      true = :ets.delete_all_objects(@table)
+      :ets.insert(@table, inserts)
+
+      Logger.info(fn ->
+        "#{__MODULE__}: updated with #{length(inserts)} records"
+      end)
+    end
+
+    {:noreply, [], state, :hibernate}
+  end
+
+  defp build_insert({:ok, row}) do
+    trip_id = copy(Map.get(row, "trip_id"))
+    stop_id = copy(Map.get(row, "stop_id"))
+    stop_sequence = String.to_integer(Map.get(row, "stop_sequence"))
+
+    {{trip_id, stop_sequence}, stop_id}
+  end
+end

--- a/lib/concentrate/filter/gtfs/supervisor.ex
+++ b/lib/concentrate/filter/gtfs/supervisor.ex
@@ -23,6 +23,7 @@ defmodule Concentrate.Filter.GTFS.Supervisor do
           },
           {Concentrate.Filter.GTFS.Trips, subscribe_to: [:gtfs_producer]},
           {Concentrate.Filter.GTFS.Stops, subscribe_to: [:gtfs_producer]},
+          {Concentrate.Filter.GTFS.StopIDs, subscribe_to: [:gtfs_producer]},
           {Concentrate.Filter.GTFS.PickupDropOff, subscribe_to: [:gtfs_producer]}
         ],
         strategy: :rest_for_one

--- a/lib/concentrate/filter/include_stop_id.ex
+++ b/lib/concentrate/filter/include_stop_id.ex
@@ -1,0 +1,34 @@
+defmodule Concentrate.Filter.IncludeStopID do
+  @moduledoc """
+  Adds missing stop IDs to StopTimeUpdates.
+  """
+  @behaviour Concentrate.Filter
+  alias Concentrate.Filter.GTFS.StopIDs
+  alias Concentrate.StopTimeUpdate
+
+  @impl Concentrate.Filter
+  def filter(item, stop_ids \\ StopIDs)
+
+  def filter(%StopTimeUpdate{} = stu, stop_ids) do
+    {:cont,
+     maybe_add_stop_id(
+       stu,
+       StopTimeUpdate.stop_id(stu),
+       StopTimeUpdate.trip_id(stu),
+       StopTimeUpdate.stop_sequence(stu),
+       stop_ids
+     )}
+  end
+
+  def filter(other, _stop_ids), do: {:cont, other}
+
+  defp maybe_add_stop_id(stu, nil, trip_id, stop_sequence, stop_ids)
+       when is_binary(trip_id) and is_integer(stop_sequence) do
+    case stop_ids.stop_id(trip_id, stop_sequence) do
+      :unknown -> stu
+      stop_id -> StopTimeUpdate.update_stop_id(stu, stop_id)
+    end
+  end
+
+  defp maybe_add_stop_id(stu, _, _, _, _), do: stu
+end

--- a/lib/concentrate/filter/null_stop_sequence.ex
+++ b/lib/concentrate/filter/null_stop_sequence.ex
@@ -1,0 +1,19 @@
+defmodule Concentrate.Filter.NullStopSequence do
+  @moduledoc """
+  Filters out StopTimeUpdates with a null `stop_sequence`, since they would not have been merged
+  correctly (and wouldn't work with downstream modules that assume a stop sequence is present).
+  """
+  @behaviour Concentrate.Filter
+  alias Concentrate.StopTimeUpdate
+  require Logger
+
+  @impl Concentrate.Filter
+  def filter(%StopTimeUpdate{} = stu) do
+    case StopTimeUpdate.stop_sequence(stu) do
+      nil -> :skip
+      _ -> {:cont, stu}
+    end
+  end
+
+  def filter(other), do: {:cont, other}
+end

--- a/lib/concentrate/stop_time_update.ex
+++ b/lib/concentrate/stop_time_update.ex
@@ -3,7 +3,6 @@ defmodule Concentrate.StopTimeUpdate do
   Structure for representing an update to a StopTime (e.g. a predicted arrival or departure)
   """
   import Concentrate.StructHelpers
-  alias Concentrate.Filter.GTFS.Stops
 
   defstruct_accessors([
     :trip_id,
@@ -36,14 +35,7 @@ defmodule Concentrate.StopTimeUpdate do
   end
 
   defimpl Concentrate.Mergeable do
-    def key(%{trip_id: trip_id, stop_id: stop_id, stop_sequence: stop_sequence}) do
-      parent_station_id =
-        if stop_id do
-          Stops.parent_station_id(stop_id)
-        end
-
-      {trip_id, parent_station_id, stop_sequence}
-    end
+    def key(%{trip_id: trip_id, stop_sequence: stop_sequence}), do: {trip_id, stop_sequence}
 
     def merge(first, second) do
       %{

--- a/test/concentrate/filter/gtfs/helpers_test.exs
+++ b/test/concentrate/filter/gtfs/helpers_test.exs
@@ -1,0 +1,13 @@
+defmodule Concentrate.Filter.GTFS.HelpersTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  alias Concentrate.Filter.GTFS.Helpers
+
+  describe "io_stream/1" do
+    test "streams the lines of a binary" do
+      stream = Helpers.io_stream("first line\nsecond line\nthird line")
+
+      assert Enum.to_list(stream) == ["first line\n", "second line\n", "third line"]
+    end
+  end
+end

--- a/test/concentrate/filter/gtfs/stop_ids_test.exs
+++ b/test/concentrate/filter/gtfs/stop_ids_test.exs
@@ -1,0 +1,38 @@
+defmodule Concentrate.Filter.GTFS.StopIDsTest do
+  @moduledoc false
+  use ExUnit.Case
+  import Concentrate.Filter.GTFS.StopIDs
+
+  # copied + modified from a recent stop_times.txt
+  @body """
+  "trip_id","arrival_time","departure_time","stop_id","stop_sequence","stop_headsign","pickup_type","drop_off_type","timepoint","checkpoint_id"
+  "Logan-22-Weekday-trip","08:00:00","08:00:00","Logan-Subway",1,"",0,1,0,""
+  """
+
+  defp supervised(_) do
+    start_supervised(Concentrate.Filter.GTFS.StopIDs)
+    event = [{"stop_times.txt", @body}]
+    # relies on being able to update the table from a different process
+    handle_events([event], :ignored, :ignored)
+    :ok
+  end
+
+  describe "stop_id" do
+    setup :supervised
+
+    test "stop ID for the trip/sequence" do
+      assert stop_id("Logan-22-Weekday-trip", 1) == "Logan-Subway"
+    end
+
+    test "unknown for unknown trips/stops" do
+      assert stop_id("unknown trip", 1) == :unknown
+      assert stop_id("Logan-22-Weekday-trip", 4) == :unknown
+    end
+  end
+
+  describe "missing ETS table" do
+    test "stop_id is unknown" do
+      assert stop_id("trip", 1) == :unknown
+    end
+  end
+end

--- a/test/concentrate/filter/include_stop_id_test.exs
+++ b/test/concentrate/filter/include_stop_id_test.exs
@@ -1,0 +1,35 @@
+defmodule Concentrate.Filter.IncludeStopIDTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  import Concentrate.Filter.IncludeStopID
+  alias Concentrate.StopTimeUpdate
+
+  @module Concentrate.Filter.FakeStopIDs
+
+  describe "filter/2" do
+    test "a stop time update with a stop_id is kept as-is" do
+      stu = StopTimeUpdate.new(trip_id: "trip", stop_id: "s", stop_sequence: 1)
+      assert {:cont, ^stu} = filter(stu, @module)
+    end
+
+    test "a stop update without a trip is kept as-is" do
+      stu = StopTimeUpdate.new([])
+      assert {:cont, ^stu} = filter(stu, @module)
+    end
+
+    test "a missing stop id is updated" do
+      stu = StopTimeUpdate.new(trip_id: "trip", stop_sequence: 1)
+      assert {:cont, new_stu} = filter(stu, @module)
+      assert StopTimeUpdate.stop_id(new_stu) == "stop"
+    end
+
+    test "unknown trip IDs are ignored" do
+      stu = StopTimeUpdate.new(trip_id: "unknown")
+      assert {:cont, ^stu} = filter(stu, @module)
+    end
+
+    test "other values are returned as-is" do
+      assert {:cont, :value} = filter(:value)
+    end
+  end
+end

--- a/test/concentrate/filter/null_stop_sequence_test.exs
+++ b/test/concentrate/filter/null_stop_sequence_test.exs
@@ -1,0 +1,22 @@
+defmodule Concentrate.Filter.NullStopSequenceTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  import Concentrate.Filter.NullStopSequence
+  alias Concentrate.StopTimeUpdate
+
+  describe "filter/1" do
+    test "skips a stop time update with a null stop_sequence" do
+      stu = StopTimeUpdate.new(stop_sequence: nil)
+      assert :skip = filter(stu)
+    end
+
+    test "passes through a stop time update with a stop_sequence" do
+      stu = StopTimeUpdate.new(stop_sequence: 1)
+      assert {:cont, ^stu} = filter(stu)
+    end
+
+    test "passes through other values" do
+      assert {:cont, :value} = filter(:value)
+    end
+  end
+end

--- a/test/concentrate/stop_time_update_test.exs
+++ b/test/concentrate/stop_time_update_test.exs
@@ -6,7 +6,6 @@ defmodule Concentrate.StopTimeUpdateTest do
 
   @stu new(
          trip_id: "trip",
-         stop_id: "stop",
          stop_sequence: 1,
          arrival_time: 2,
          departure_time: 3,
@@ -28,22 +27,13 @@ defmodule Concentrate.StopTimeUpdateTest do
   end
 
   describe "Concentrate.Mergeable" do
-    test "key/1 uses the parent station ID" do
-      start_supervised!(Concentrate.Filter.GTFS.Stops)
-      Concentrate.Filter.GTFS.Stops._insert_mapping("child_id", "parent_id")
-
-      assert Mergeable.key(new(stop_id: "child_id")) == {nil, "parent_id", nil}
-      assert Mergeable.key(new(stop_id: "other")) == {nil, "other", nil}
-      assert Mergeable.key(new(stop_id: nil)) == {nil, nil, nil}
-    end
-
-    test "merge/2 takes non-nil values, earliest arrival, latest departure" do
+    test "takes non-nil values, earliest arrival, latest departure" do
       first = @stu
 
       second =
         new(
           trip_id: "trip",
-          stop_id: "stop-01",
+          stop_id: "stop",
           stop_sequence: 1,
           arrival_time: 1,
           departure_time: 4,
@@ -55,7 +45,7 @@ defmodule Concentrate.StopTimeUpdateTest do
       expected =
         new(
           trip_id: "trip",
-          stop_id: "stop-01",
+          stop_id: "stop",
           stop_sequence: 1,
           arrival_time: 1,
           departure_time: 4,
@@ -68,6 +58,14 @@ defmodule Concentrate.StopTimeUpdateTest do
 
       assert Mergeable.merge(first, second) == expected
       assert Mergeable.merge(second, first) == expected
+    end
+
+    test "picks the 'greater' of two stop IDs" do
+      first = new(stop_id: "stop")
+      second = new(stop_id: "stop-01")
+
+      assert %{stop_id: "stop-01"} = Mergeable.merge(first, second)
+      assert %{stop_id: "stop-01"} = Mergeable.merge(second, first)
     end
   end
 end

--- a/test/support/filter/fakes.ex
+++ b/test/support/filter/fakes.ex
@@ -7,6 +7,12 @@ defmodule Concentrate.Filter.FakeTrips do
   def direction_id(_), do: nil
 end
 
+defmodule Concentrate.Filter.FakeStopIDs do
+  @moduledoc "Fake implementation of Filter.GTFS.StopIDs"
+  def stop_id("trip", 1), do: "stop"
+  def stop_id(_, _), do: :unknown
+end
+
 defmodule Concentrate.Filter.FakeCancelledTrips do
   @moduledoc "Fake implementation of Filter.Alerts.CancelledTrips"
   def route_cancelled?("route", {1970, 1, 2}) do


### PR DESCRIPTION
Previously we merged StopTimeUpdates using a "key" of trip ID + stop ID + stop sequence. Since stop ID and sequence are both optional (only one needs to be present), this created the potential for duplicates: two updates that referred to the same stop would not be merged if one of them used a sequence and the other used a stop ID.

Given:

1. it's not universally possible to merge StopTimeUpdates without a stop sequence (it's required if a trip contains a loop)
2. merging updates correctly using "maybe stop ID or sequence or both" would require significant changes to the merging system
3. grouping and the `RemoveUnneededTimes` filter assume the presence of stop sequences
4. all our current input feeds either include stop sequences already or are planned to

...we can simplify things by explicitly requiring a stop sequence, and only merging based on trip ID + stop sequence.

This also includes a refreshed version of an old unmerged feature (#84) that uses static GTFS to fill in stop IDs for updates that only have a stop sequence. Since we are now merging only on stop sequence, it makes sense to not require input feeds to have stop IDs, although this will probably continue to be true for all of our own input feeds.

~~**Note:** If merged, this will effectively disable the `busloc` feed until it is updated to include stop sequences. This might be fine, since attempting to ingest it with the current logic is causing some issues (duplicate updates, departure times at final stops) we might prefer to fix. But, if the current situation is tolerable, we could leave this open until the change is made in `busloc`.~~