### PR TITLE
docs: README change of file path for symbolic linking pre-commit under hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ asdf install
 mix deps.get
 
 # add pre-commit hook to verify formatting/tests/types
-ln -s ../../hooks/pre-commit .git/hooks/pre-commit
+ln -s ./hooks/pre-commit .git/hooks/pre-commit
 
 # make sure everything passes! (slowest to fastest)
 mix format --check-formatted

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ asdf install
 mix deps.get
 
 # add pre-commit hook to verify formatting/tests/types
-ln -s ./hooks/pre-commit .git/hooks/pre-commit
+ln -s hooks/pre-commit .git/hooks/pre-commit
 
 # make sure everything passes! (slowest to fastest)
 mix format --check-formatted


### PR DESCRIPTION
README change of file path for symbolic linking of pre-commit under hooks