### PR TITLE
fix: align ECS service name with Terraform

### DIFF
--- a/.github/workflows/dev-green.yml
+++ b/.github/workflows/dev-green.yml
@@ -22,7 +22,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ecs-cluster: concentrate
-          ecs-service: concentrate-dev-green-fargate
+          ecs-service: concentrate-dev-green
           docker-tag: ${{ steps.build-push.outputs.docker-tag }}
       - uses: mbta/actions/notify-slack-deploy@v1
         if: ${{ !cancelled() }}


### PR DESCRIPTION
When https://github.com/mbta/devops/pull/381 is applied, the dev green service will be renamed to concentrate-dev-green. This PR aligns the deployment workflow with that change.