### PR TITLE
deps: update to latest release of Erlang 23

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.10.3-otp-23
-erlang 23.0.2
+elixir 1.10.4-otp-23
+erlang 23.3.4.14

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.10.3-erlang-23.0.2-alpine-3.11.6 AS builder
+FROM hexpm/elixir:1.10.4-erlang-23.3.4.14-alpine-3.16.0 AS builder
 
 WORKDIR /root
 
@@ -22,7 +22,7 @@ ADD src /root/src
 RUN mix do compile, release
 
 # Second stage: copies the files from the builder stage
-FROM alpine:3.11.6
+FROM alpine:3.16.0
 
 RUN apk add --update libssl1.1 ncurses-libs bash dumb-init \
     && rm -rf /var/cache/apk


### PR DESCRIPTION
The project's previous version of Erlang no longer builds on current versions of macOS, which is a blocker for continued work on it.