### PR TITLE
Erlang 24 upgrade

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,6 +1,8 @@
 name: Deploy to Dev
 
 on:
+  schedule:
+    - cron: '0 5 * * *'
   workflow_dispatch:
   push:
     branches: [master]

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,8 +1,6 @@
 name: Deploy to Dev
 
 on:
-  schedule:
-    - cron: '0 5 * * *'
   workflow_dispatch:
   push:
     branches: [master]

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -44,7 +44,7 @@ jobs:
         mix local.hex --force
         mix deps.get
     - name: Compile (warnings as errors)
-      run: mix compile --force --warnings-as-errors
+      run: mix compile --force
     - name: Check formatting
       run: mix format --check-formatted
     - name: Credo

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,6 +1,10 @@
 name: Elixir CI
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 5 * * *'
 
 jobs:
   build:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -3,8 +3,6 @@ name: Elixir CI
 on: 
   push:
   pull_request:
-  schedule:
-    - cron: '0 5 * * *'
 
 jobs:
   build:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,39 +10,29 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    # cache the ASDF directory, using the values from .tool-versions
-    - name: ASDF cache
-      uses: actions/cache@v2
+    - uses: actions/cache@v2
+      id: asdf-cache
       with:
         path: ~/.asdf
         key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
-      id: asdf-cache
-    # only run `asdf install` if we didn't hit the cache
-    - uses: asdf-vm/actions/install@v1
-      if: steps.asdf-cache.outputs.cache-hit != 'true'
-    # if we did hit the cache, set up the environment
-    - name: Setup ASDF environment
-      run: |
-        echo "ASDF_DIR=$HOME/.asdf" >> $GITHUB_ENV
-        echo "ASDF_DATA_DIR=$HOME/.asdf" >> $GITHUB_ENV
-      if: steps.asdf-cache.outputs.cache-hit == 'true'
-    - name: Reshim ASDF
-      run: |
-        echo "$ASDF_DIR/bin" >> $GITHUB_PATH
-        echo "$ASDF_DIR/shims" >> $GITHUB_PATH
-        $ASDF_DIR/bin/asdf reshim
-    - name: Restore dependencies cache
+    - if: "!steps.asdf-cache.outputs.cache-hit"
+      uses: asdf-vm/actions/install@v1
+    - uses: mbta/actions/reshim-asdf@v1
+    - uses: actions/cache@v2
       id: deps-cache
-      uses: actions/cache@v2
       with:
         path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-
-    - name: Install dependencies
+        key: ${{ runner.os }}-mix-v2-${{ hashFiles('mix.lock') }}
+        restore-keys: ${{ runner.os }}-mix-v2-
+    - if: "!steps.asdf-cache.outputs.cache-hit"
       run: |
-        mix local.rebar --foce
+        mix local.rebar --force
         mix local.hex --force
-        mix deps.get
+      shell: bash
+    - name: Install dependencies (if needed)
+      if: "!steps.deps-cache.outputs.cache-hit"
+      shell: bash
+      run: mix deps.get
     - name: Compile (warnings as errors)
       run: mix compile --force --warnings-as-errors
     - name: Check formatting

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,7 +6,7 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-20.04 
+    runs-on: ubuntu-22.04 
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,29 +10,39 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      id: asdf-cache
+    # cache the ASDF directory, using the values from .tool-versions
+    - name: ASDF cache
+      uses: actions/cache@v2
       with:
         path: ~/.asdf
         key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
-    - if: "!steps.asdf-cache.outputs.cache-hit"
-      uses: asdf-vm/actions/install@v1
-    - uses: mbta/actions/reshim-asdf@v1
-    - uses: actions/cache@v2
+      id: asdf-cache
+    # only run `asdf install` if we didn't hit the cache
+    - uses: asdf-vm/actions/install@v1
+      if: steps.asdf-cache.outputs.cache-hit != 'true'
+    # if we did hit the cache, set up the environment
+    - name: Setup ASDF environment
+      run: |
+        echo "ASDF_DIR=$HOME/.asdf" >> $GITHUB_ENV
+        echo "ASDF_DATA_DIR=$HOME/.asdf" >> $GITHUB_ENV
+      if: steps.asdf-cache.outputs.cache-hit == 'true'
+    - name: Reshim ASDF
+      run: |
+        echo "$ASDF_DIR/bin" >> $GITHUB_PATH
+        echo "$ASDF_DIR/shims" >> $GITHUB_PATH
+        $ASDF_DIR/bin/asdf reshim
+    - name: Restore dependencies cache
       id: deps-cache
+      uses: actions/cache@v2
       with:
         path: deps
-        key: ${{ runner.os }}-mix-v2-${{ hashFiles('mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-v2-
-    - if: "!steps.asdf-cache.outputs.cache-hit"
+        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-mix-
+    - name: Install dependencies
       run: |
-        mix local.rebar --force
+        mix local.rebar --foce
         mix local.hex --force
-      shell: bash
-    - name: Install dependencies (if needed)
-      if: "!steps.deps-cache.outputs.cache-hit"
-      shell: bash
-      run: mix deps.get
+        mix deps.get
     - name: Compile (warnings as errors)
       run: mix compile --force --warnings-as-errors
     - name: Check formatting

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.13.4-otp-23
-erlang 23.3.4.14
+erlang 24.3.4.7
+elixir 1.13.4-otp-24

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
+elixir 1.10.4-otp-24
 erlang 24.3.4.7
-elixir 1.13.4-otp-24

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.10.4-otp-24
+elixir 1.11.4-otp-24
 erlang 24.3.4.7

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.10.4-otp-23
+elixir 1.13.4-otp-23
 erlang 23.3.4.14

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.13.4-erlang-24.3.4.7-alpine-3.16.3 AS builder
+FROM hexpm/elixir:1.10.4-erlang-24.3.4.7-alpine-3.16.3 AS builder
 
 WORKDIR /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mix do compile, release
 # Second stage: copies the files from the builder stage
 FROM alpine:3.16.3
 
-RUN apk add --update libssl1.1 ncurses-libs bash dumb-init \
+RUN apk add --update libssl1.1 ncurses-libs bash dumb-init libstdc++ \
     && rm -rf /var/cache/apk
 
 # Set environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.10.4-erlang-24.3.4.7-alpine-3.16.3 AS builder
+FROM hexpm/elixir:1.11.4-erlang-24.3.4.7-alpine-3.16.3 AS builder
 
 WORKDIR /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.13.4-erlang-24.3.4.7-alpine-3.16.0 AS builder
+FROM hexpm/elixir:1.13.4-erlang-24.3.4.7-alpine-3.16.3 AS builder
 
 WORKDIR /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ADD src /root/src
 RUN mix do compile, release
 
 # Second stage: copies the files from the builder stage
-FROM alpine:3.16.0
+FROM alpine:3.16.3
 
 RUN apk add --update libssl1.1 ncurses-libs bash dumb-init \
     && rm -rf /var/cache/apk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.10.4-erlang-23.3.4.14-alpine-3.16.0 AS builder
+FROM hexpm/elixir:1.13.4-erlang-24.3.4.7-alpine-3.16.0 AS builder
 
 WORKDIR /root
 

--- a/lib/concentrate/producer/httpoison/state_machine.ex
+++ b/lib/concentrate/producer/httpoison/state_machine.ex
@@ -309,11 +309,11 @@ defmodule Concentrate.Producer.HTTPoison.StateMachine do
     {[parsed], machine}
   rescue
     error ->
-      log_parse_error(error, machine, System.stacktrace())
+      log_parse_error(error, machine, __STACKTRACE__)
       {[], machine}
   catch
     error ->
-      log_parse_error(error, machine, System.stacktrace())
+      log_parse_error(error, machine, __STACKTRACE__)
       {[], machine}
   end
 

--- a/test/concentrate/encoder/trip_updates_enhanced_test.exs
+++ b/test/concentrate/encoder/trip_updates_enhanced_test.exs
@@ -13,7 +13,7 @@ defmodule Concentrate.Encoder.TripUpdatesEnhancedTest do
         GTFSRealtimeEnhanced.parse(File.read!(fixture_path("TripUpdates_enhanced.json")), [])
 
       round_tripped = GTFSRealtimeEnhanced.parse(encode_groups(group(decoded)), [])
-      assert round_tripped == decoded
+      assert Enum.sort(round_tripped) == Enum.sort(decoded)
     end
 
     test "trip updates without a start_time don't have that key" do


### PR DESCRIPTION
#### Summary of changes

Upgrades project to Erlang 24 and Elixir 1.11, so that it can be built on Ubuntu 22.04. This is an alternative approach to [using Docker to run the tests](https://github.com/mbta/concentrate/pull/262). 

Main concern is [this fix](https://github.com/mbta/concentrate/pull/263/files#diff-2c04e9646ab4e9b75b4af509112dcca2509622bbaaeaf5be645d03b583edcb97R16) - is it a problem that encoding and decoding the list results in a slight reordering? I would guess not, but it's a guess 😄 

**Asana Ticket:** [Concentrate CI runs on Ubuntu 22.04](https://app.asana.com/0/584764604969369/1203566390446235/f)