### PR TITLE
Temporarily suppress terminal/reverse trip predictions for Red Line and Blue Line in Concentrate

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,6 +37,10 @@ config :concentrate,
   ],
   group_filters: [
     {
+      Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates,
+      uncertainties_by_route: %{"Red" => [120, 360], "Blue" => [120, 360]}
+    },
+    {
       Concentrate.GroupFilter.ScheduledStopTimes,
       # https://github.com/mbta/commuter_rail_boarding/blob/79a493f/config/config.exs#L34-L63
       on_time_statuses: ["All aboard", "Now boarding", "On time", "On Time"]

--- a/lib/concentrate/group_filter/remove_uncertain_stop_time_updates.ex
+++ b/lib/concentrate/group_filter/remove_uncertain_stop_time_updates.ex
@@ -31,7 +31,7 @@ defmodule Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates do
 
   def filter(group, exclusions) when exclusions == %{}, do: group
 
-  def filter({nil, _, _} = group, exclusions) when exclusions == %{}, do: group
+  def filter({nil, _, _} = group, _), do: group
 
   def filter({trip_descriptor, vehicle_positions, stop_time_updates}, exclusions) do
     route_id = TripDescriptor.route_id(trip_descriptor)

--- a/lib/concentrate/group_filter/remove_uncertain_stop_time_updates.ex
+++ b/lib/concentrate/group_filter/remove_uncertain_stop_time_updates.ex
@@ -31,6 +31,8 @@ defmodule Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates do
 
   def filter(group, exclusions) when exclusions == %{}, do: group
 
+  def filter({nil, _, _} = group, exclusions) when exclusions == %{}, do: group
+
   def filter({trip_descriptor, vehicle_positions, stop_time_updates}, exclusions) do
     route_id = TripDescriptor.route_id(trip_descriptor)
     route_exclusions = Map.get(exclusions, route_id, nil)

--- a/lib/concentrate/group_filter/remove_uncertain_stop_time_updates.ex
+++ b/lib/concentrate/group_filter/remove_uncertain_stop_time_updates.ex
@@ -1,0 +1,46 @@
+defmodule Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates do
+  @moduledoc """
+  The excluded uncertainty values for each route must be set in app configuration
+  at compile time. For example:
+
+      config :concentrate,
+        group_filters: [
+          {
+            Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates,
+            on_time_statuses: ["status 1", "status 2", "status 3"]
+          }
+        ]
+
+  If no status values are configured, enabling this filter has no effect.
+  """
+  alias Concentrate.TripDescriptor
+  alias Concentrate.StopTimeUpdate
+
+  @behaviour Concentrate.GroupFilter
+
+  @type route_id() :: String.t()
+  @type uncertainties() :: [integer()]
+  @type uncertainties_by_route() :: %{
+          route_id() => uncertainties()
+        }
+
+  config_path = [:group_filters, __MODULE__, :uncertainties_by_route]
+  @uncertainties_by_route Application.compile_env(:concentrate, config_path, %{})
+
+  def filter(trip_descriptor, exclusions \\ @uncertainties_by_route)
+
+  def filter(group, exclusions) when exclusions == %{}, do: group
+
+  def filter({trip_descriptor, vehicle_positions, stop_time_updates}, exclusions) do
+    route_id = TripDescriptor.route_id(trip_descriptor)
+    route_exclusions = Map.get(exclusions, route_id, nil)
+    {trip_descriptor, vehicle_positions, exclude(stop_time_updates, route_exclusions)}
+  end
+
+  @spec exclude([StopTimeUpdate.t()], uncertainties() | nil) :: [StopTimeUpdate.t()]
+  defp exclude(updates, nil), do: updates
+
+  defp exclude(updates, uncertainties) do
+    Enum.reject(updates, &(StopTimeUpdate.uncertainty(&1) in uncertainties))
+  end
+end

--- a/lib/concentrate/group_filter/remove_uncertain_stop_time_updates.ex
+++ b/lib/concentrate/group_filter/remove_uncertain_stop_time_updates.ex
@@ -27,6 +27,7 @@ defmodule Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates do
   config_path = [:group_filters, __MODULE__, :uncertainties_by_route]
   @uncertainties_by_route Application.compile_env(:concentrate, config_path, %{})
 
+  @impl Concentrate.GroupFilter
   def filter(trip_descriptor, exclusions \\ @uncertainties_by_route)
 
   def filter(group, exclusions) when exclusions == %{}, do: group

--- a/lib/concentrate/group_filter/remove_uncertain_stop_time_updates.ex
+++ b/lib/concentrate/group_filter/remove_uncertain_stop_time_updates.ex
@@ -7,11 +7,11 @@ defmodule Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates do
         group_filters: [
           {
             Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates,
-            on_time_statuses: ["status 1", "status 2", "status 3"]
+            uncertainties_by_route: ["status 1", "status 2", "status 3"]
           }
         ]
 
-  If no status values are configured, enabling this filter has no effect.
+  If no uncertainty values are configured, enabling this filter has no effect.
   """
   alias Concentrate.TripDescriptor
   alias Concentrate.StopTimeUpdate

--- a/test/concentrate/group_filter/remove_uncertain_stop_time_updates_test.exs
+++ b/test/concentrate/group_filter/remove_uncertain_stop_time_updates_test.exs
@@ -9,33 +9,40 @@ defmodule Concentrate.GroupFilter.RemoveUncertainStopTimesTest do
   @reverse_prediction 360
 
   describe "filter/2" do
+    test "handles nil TripDescriptors" do
+      group =
+        {nil, [], [StopTimeUpdate.new(trip_id: "green_c_trip", uncertainty: @reverse_prediction)]}
+
+      assert RemoveUncertainStopTimeUpdates.filter(group, %{"Red" => [@at_terminal, @reverse_prediction]}) == group
+    end
+
     test "keeps terminal and reverse predictions for routes not specified" do
-      trip_update =
+      group =
         {TripDescriptor.new(trip_id: "green_c_trip", route_id: "Green-C"), [],
          [StopTimeUpdate.new(trip_id: "green_c_trip", uncertainty: @reverse_prediction)]}
 
-      assert RemoveUncertainStopTimeUpdates.filter(trip_update, %{}) == trip_update
+      assert RemoveUncertainStopTimeUpdates.filter(group, %{}) == group
     end
 
     test "keeps terminal and reverse predictions for specified routes for uncertainties not specified" do
-      trip_update =
+      group =
         {TripDescriptor.new(trip_id: "red_trip", route_id: "Red"), [],
          [StopTimeUpdate.new(trip_id: "red_trip", uncertainty: @mid_trip)]}
 
-      assert RemoveUncertainStopTimeUpdates.filter(trip_update, %{
+      assert RemoveUncertainStopTimeUpdates.filter(group, %{
                "Red" => [@at_terminal, @reverse_prediction]
-             }) == trip_update
+             }) == group
     end
 
     test "removes uncertain predictions for specified routes" do
-      trip_update =
+      group =
         {TripDescriptor.new(trip_id: "red_trip", route_id: "Red"), [],
          [
            StopTimeUpdate.new(trip_id: "red_trip", uncertainty: @at_terminal),
            StopTimeUpdate.new(trip_id: "red_trip", uncertainty: @reverse_prediction)
          ]}
 
-      assert RemoveUncertainStopTimeUpdates.filter(trip_update, %{
+      assert RemoveUncertainStopTimeUpdates.filter(group, %{
                "Red" => [@at_terminal, @reverse_prediction]
              }) ==
                {TripDescriptor.new(trip_id: "red_trip", route_id: "Red"), [], []}

--- a/test/concentrate/group_filter/remove_uncertain_stop_time_updates_test.exs
+++ b/test/concentrate/group_filter/remove_uncertain_stop_time_updates_test.exs
@@ -1,0 +1,44 @@
+defmodule Concentrate.GroupFilter.RemoveUncertainStopTimesTest do
+  use ExUnit.Case, async: true
+  alias Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates
+  alias Concentrate.TripDescriptor
+  alias Concentrate.StopTimeUpdate
+
+  @mid_trip 60
+  @at_terminal 120
+  @reverse_prediction 360
+
+  describe "filter/2" do
+    test "keeps terminal and reverse predictions for routes not specified" do
+      trip_update =
+        {TripDescriptor.new(trip_id: "green_c_trip", route_id: "Green-C"), [],
+         [StopTimeUpdate.new(trip_id: "green_c_trip", uncertainty: @reverse_prediction)]}
+
+      assert RemoveUncertainStopTimeUpdates.filter(trip_update, %{}) == trip_update
+    end
+
+    test "keeps terminal and reverse predictions for specified routes for uncertainties not specified" do
+      trip_update =
+        {TripDescriptor.new(trip_id: "red_trip", route_id: "Red"), [],
+         [StopTimeUpdate.new(trip_id: "red_trip", uncertainty: @mid_trip)]}
+
+      assert RemoveUncertainStopTimeUpdates.filter(trip_update, %{
+               "Red" => [@at_terminal, @reverse_prediction]
+             }) == trip_update
+    end
+
+    test "removes uncertain predictions for specified routes" do
+      trip_update =
+        {TripDescriptor.new(trip_id: "red_trip", route_id: "Red"), [],
+         [
+           StopTimeUpdate.new(trip_id: "red_trip", uncertainty: @at_terminal),
+           StopTimeUpdate.new(trip_id: "red_trip", uncertainty: @reverse_prediction)
+         ]}
+
+      assert RemoveUncertainStopTimeUpdates.filter(trip_update, %{
+               "Red" => [@at_terminal, @reverse_prediction]
+             }) ==
+               {TripDescriptor.new(trip_id: "red_trip", route_id: "Red"), [], []}
+    end
+  end
+end

--- a/test/concentrate/group_filter/remove_uncertain_stop_time_updates_test.exs
+++ b/test/concentrate/group_filter/remove_uncertain_stop_time_updates_test.exs
@@ -13,7 +13,9 @@ defmodule Concentrate.GroupFilter.RemoveUncertainStopTimesTest do
       group =
         {nil, [], [StopTimeUpdate.new(trip_id: "green_c_trip", uncertainty: @reverse_prediction)]}
 
-      assert RemoveUncertainStopTimeUpdates.filter(group, %{"Red" => [@at_terminal, @reverse_prediction]}) == group
+      assert RemoveUncertainStopTimeUpdates.filter(group, %{
+               "Red" => [@at_terminal, @reverse_prediction]
+             }) == group
     end
 
     test "keeps terminal and reverse predictions for routes not specified" do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] 🧠 Temporarily suppress terminal/reverse trip predictions for Red Line and Blue Line in Concentrate](https://app.asana.com/0/584764604969369/1204348457726555/f)

Adds a new GroupFilter that removes uncertain StopTimeUpdates from a group that match a route_id and uncertainty value specified as a map in `config.exs`. Also updates `config.exs` to suppress Red and Blue line terminal and reverse predictions while we wait for schedules to recover.
