### PR TITLE
chore: reenable Red Line terminal and reverse predictions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,7 +38,7 @@ config :concentrate,
   group_filters: [
     {
       Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates,
-      uncertainties_by_route: %{"Red" => [120, 360], "Blue" => [120, 360]}
+      uncertainties_by_route: %{"Blue" => [120, 360]}
     },
     {
       Concentrate.GroupFilter.ScheduledStopTimes,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] [Pending Decision] 🧠 Reenable terminal/reverse trip predictions in Concentrate for the Red Line](https://app.asana.com/0/505721188639414/1204373209135067/f)

Removes `"Red"` from the map of routes used to filter uncertain StopTimeUpdates.