### PR TITLE
chore: Elixir 1.14 and Erlang 25

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.11.4-otp-24
-erlang 24.3.4.7
+elixir 1.14.5-otp-25
+erlang 25.2.3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.14.5-otp-25
-erlang 25.2.3
+erlang 25.3.2.1

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 config :logger, level: :debug
 
@@ -79,4 +79,4 @@ config :concentrate,
   ],
   http_producer: Concentrate.Producer.HTTPoison
 
-import_config "#{Mix.env()}.exs"
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,3 +1,5 @@
-use Mix.Config
+import Config
 
-import_config "*.local.exs"
+for config <- "*.local.exs" |> Path.expand(__DIR__) |> Path.wildcard() do
+  import_config config
+end

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :sasl, errlog_type: :error
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :logger,
   level: :info,

--- a/lib/concentrate/parser/helpers.ex
+++ b/lib/concentrate/parser/helpers.ex
@@ -104,7 +104,7 @@ defmodule Concentrate.Parser.Helpers do
   end
 
   def valid_route_id?(%{excluded_routes: {:ok, route_ids}}, route_id) do
-    not (route_id in route_ids)
+    route_id not in route_ids
   end
 
   def valid_route_id?(_, _) do
@@ -141,11 +141,7 @@ defmodule Concentrate.Parser.Helpers do
              vehicle_timestamp > feed_timestamp do
     _ =
       Logger.warn(
-        "vehicle timestamp after feed timestamp feed_url=#{inspect(options.feed_url)} vehicle_id=#{
-          inspect(vehicle_id)
-        } feed_timestamp=#{inspect(feed_timestamp)} vehicle_timestamp=#{
-          inspect(vehicle_timestamp)
-        }"
+        "vehicle timestamp after feed timestamp feed_url=#{inspect(options.feed_url)} vehicle_id=#{inspect(vehicle_id)} feed_timestamp=#{inspect(feed_timestamp)} vehicle_timestamp=#{inspect(vehicle_timestamp)}"
       )
 
     :ok

--- a/lib/concentrate/producer/httpoison/state_machine.ex
+++ b/lib/concentrate/producer/httpoison/state_machine.ex
@@ -216,9 +216,7 @@ defmodule Concentrate.Producer.HTTPoison.StateMachine do
   defp handle_message(machine, unknown) do
     _ =
       Logger.error(fn ->
-        "#{__MODULE__}: got unexpected message url=#{inspect(machine.url)} message=#{
-          inspect(unknown)
-        }"
+        "#{__MODULE__}: got unexpected message url=#{inspect(machine.url)} message=#{inspect(unknown)}"
       end)
 
     {machine, [], []}
@@ -293,9 +291,7 @@ defmodule Concentrate.Producer.HTTPoison.StateMachine do
 
     _ =
       Logger.info(fn ->
-        "#{__MODULE__} updated: url=#{inspect(url(machine))} records=#{length(parsed)} time=#{
-          time / 1000
-        }"
+        "#{__MODULE__} updated: url=#{inspect(url(machine))} records=#{length(parsed)} time=#{time / 1000}"
       end)
 
     machine =
@@ -320,9 +316,7 @@ defmodule Concentrate.Producer.HTTPoison.StateMachine do
   defp log_parse_error(error, machine, trace) do
     _ =
       Logger.error(fn ->
-        "#{__MODULE__}: parse error url=#{inspect(machine.url)} error=#{inspect(error)}\n#{
-          Exception.format_stacktrace(trace)
-        }"
+        "#{__MODULE__}: parse error url=#{inspect(machine.url)} error=#{inspect(error)}\n#{Exception.format_stacktrace(trace)}"
       end)
 
     []
@@ -347,9 +341,7 @@ defmodule Concentrate.Producer.HTTPoison.StateMachine do
   defp activate_fallback(%{fallback: {:not_active, url}} = machine) do
     _ =
       Logger.error(fn ->
-        "#{__MODULE__} activating fallback url=#{inspect(machine.url)} fallback_url=#{
-          inspect(url)
-        }"
+        "#{__MODULE__} activating fallback url=#{inspect(machine.url)} fallback_url=#{inspect(url)}"
       end)
 
     fallback_machine =

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,6 @@ defmodule Concentrate.MixProject do
       dialyzer: [
         plt_add_deps: :transitive,
         flags: [
-          :race_conditions,
           :unmatched_returns,
           :underspecs,
           :unknown


### PR DESCRIPTION
#### Summary of changes

No Ticket

Updates to Elixir 1.14 and Erlang 25. Erlang 26 was not used due to critical bugs in OTP-26:
https://github.com/erlang/otp/issues/7132
https://github.com/erlang/otp/issues/7230