### PR TITLE
Don't mix predictions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -54,7 +54,8 @@ config :concentrate,
     Concentrate.GroupFilter.VehicleAtSkippedStop,
     Concentrate.GroupFilter.VehicleStopMatch,
     Concentrate.GroupFilter.SkippedStopOnAddedTrip,
-    Concentrate.GroupFilter.TripDescriptorTimestamp
+    Concentrate.GroupFilter.TripDescriptorTimestamp,
+    Concentrate.GroupFilter.TimeTravel
   ],
   reporters: [
     Concentrate.Reporter.VehicleLatency,

--- a/lib/concentrate/group_filter/time_travel.ex
+++ b/lib/concentrate/group_filter/time_travel.ex
@@ -28,6 +28,7 @@ defmodule Concentrate.GroupFilter.TimeTravel do
       Logger.warning("""
       Trip ID: #{stop_time_update.trip_id} predicts arriving at stop #{stop_time_update.stop_sequence} at #{time}
       before departing stop #{prev.stop_sequence} at #{prev_time}. Dropping prior predictions.
+      trip_id=#{stop_time_update.trip_id} stop_sequence=#{stop_time_update.stop_sequence}
       """)
 
       [stop_time_update]

--- a/lib/concentrate/group_filter/time_travel.ex
+++ b/lib/concentrate/group_filter/time_travel.ex
@@ -7,32 +7,32 @@ defmodule Concentrate.GroupFilter.TimeTravel do
   @behaviour Concentrate.GroupFilter
   @impl Concentrate.GroupFilter
 
-  def filter({td, vps, stus}) do
-    stus =
-      stus
-      |> Enum.reduce([], &filter_stu/2)
+  def filter({td, vps, stop_time_updates}) do
+    stop_time_updates =
+      stop_time_updates
+      |> Enum.reduce([], &filter_stop_time_update/2)
       |> Enum.reverse()
 
-    {td, vps, stus}
+    {td, vps, stop_time_updates}
   end
 
-  defp filter_stu(stu, []) do
-    [stu]
+  defp filter_stop_time_update(stop_time_update, []) do
+    [stop_time_update]
   end
 
-  defp filter_stu(stu, [prev | _] = stus) do
+  defp filter_stop_time_update(stop_time_update, [prev | _] = stop_time_updates) do
     prev_time = prev.departure_time || prev.arrival_time
-    time = stu.arrival_time || stu.departure_time
+    time = stop_time_update.arrival_time || stop_time_update.departure_time
 
     if time < prev_time do
       Logger.warning("""
-      Trip ID: #{stu.trip_id} predicts arriving at stop #{stu.stop_sequence} at #{time}
+      Trip ID: #{stop_time_update.trip_id} predicts arriving at stop #{stop_time_update.stop_sequence} at #{time}
       before departing stop #{prev.stop_sequence} at #{prev_time}. Dropping prior predictions.
       """)
 
-      [stu]
+      [stop_time_update]
     else
-      [stu | stus]
+      [stop_time_update | stop_time_updates]
     end
   end
 end

--- a/lib/concentrate/group_filter/time_travel.ex
+++ b/lib/concentrate/group_filter/time_travel.ex
@@ -1,0 +1,38 @@
+defmodule Concentrate.GroupFilter.TimeTravel do
+  @moduledoc """
+  Drops StopTimeUpdates that predict arriving at a later stop before departing an earlier one..
+  """
+  require Logger
+
+  @behaviour Concentrate.GroupFilter
+  @impl Concentrate.GroupFilter
+
+  def filter({td, vps, stus}) do
+    stus =
+      stus
+      |> Enum.reduce([], &filter_stu/2)
+      |> Enum.reverse()
+
+    {td, vps, stus}
+  end
+
+  defp filter_stu(stu, []) do
+    [stu]
+  end
+
+  defp filter_stu(stu, [prev | _] = stus) do
+    prev_time = prev.departure_time || prev.arrival_time
+    time = stu.arrival_time || stu.departure_time
+
+    if time < prev_time do
+      Logger.warning("""
+      Trip ID: #{stu.trip_id} predicts arriving at stop #{stu.stop_sequence} at #{time}
+      before departing stop #{prev.stop_sequence} at #{prev_time}. Dropping prior predictions.
+      """)
+
+      [stu]
+    else
+      [stu | stus]
+    end
+  end
+end

--- a/lib/concentrate/stop_time_update.ex
+++ b/lib/concentrate/stop_time_update.ex
@@ -38,10 +38,12 @@ defmodule Concentrate.StopTimeUpdate do
     def key(%{trip_id: trip_id, stop_sequence: stop_sequence}), do: {trip_id, stop_sequence}
 
     def merge(first, second) do
+      [first, second] = Enum.sort_by([first, second], &Concentrate.StopTimeUpdate.time/1)
+
       %{
         first
-        | arrival_time: time(:lt, first.arrival_time, second.arrival_time),
-          departure_time: time(:gt, first.departure_time, second.departure_time),
+        | arrival_time: first.arrival_time,
+          departure_time: first.departure_time,
           status: first.status || second.status,
           track: first.track || second.track,
           schedule_relationship:
@@ -55,12 +57,5 @@ defmodule Concentrate.StopTimeUpdate do
           uncertainty: first.uncertainty || second.uncertainty
       }
     end
-
-    defp time(_, nil, time), do: time
-    defp time(_, time, nil), do: time
-    defp time(_, time, time), do: time
-    defp time(:lt, first, second) when first < second, do: first
-    defp time(:gt, first, second) when first > second, do: first
-    defp time(_, _, second), do: second
   end
 end

--- a/lib/concentrate/stop_time_update.ex
+++ b/lib/concentrate/stop_time_update.ex
@@ -38,12 +38,15 @@ defmodule Concentrate.StopTimeUpdate do
     def key(%{trip_id: trip_id, stop_sequence: stop_sequence}), do: {trip_id, stop_sequence}
 
     def merge(first, second) do
-      [first, second] = Enum.sort_by([first, second], &Concentrate.StopTimeUpdate.time/1)
+      time_stu =
+        if Concentrate.StopTimeUpdate.time(first) < Concentrate.StopTimeUpdate.time(second),
+          do: first,
+          else: second
 
       %{
         first
-        | arrival_time: first.arrival_time,
-          departure_time: first.departure_time,
+        | arrival_time: time_stu.arrival_time,
+          departure_time: time_stu.departure_time,
           status: first.status || second.status,
           track: first.track || second.track,
           schedule_relationship:

--- a/test/concentrate/group_filter/time_travel_test.exs
+++ b/test/concentrate/group_filter/time_travel_test.exs
@@ -1,0 +1,80 @@
+defmodule Concentrate.GroupFilter.TimeTravelTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  alias Concentrate.GroupFilter.TimeTravel
+  alias Concentrate.{TripDescriptor, StopTimeUpdate}
+
+  defp build_trip(timings) do
+    td = %TripDescriptor{
+      trip_id: "trip",
+      start_time: "00:00:00",
+      start_date: "20190101"
+    }
+
+    stus =
+      timings
+      |> Enum.with_index(1)
+      |> Enum.map(fn {{arrival, departure}, sequence} ->
+        %StopTimeUpdate{
+          trip_id: "trip",
+          stop_sequence: sequence,
+          arrival_time: arrival,
+          departure_time: departure
+        }
+      end)
+
+    {td, [], stus}
+  end
+
+  defp trip_stops({_, _, stus}) do
+    Enum.map(stus, & &1.stop_sequence)
+  end
+
+  test "does not affect linear trips" do
+    expected_trip =
+      build_trip([
+        {nil, 1},
+        {2, 3},
+        {4, 5},
+        {9, 12},
+        {15, nil}
+      ])
+
+    {td, vp, stus} = expected_trip
+    actual_trip = TimeTravel.filter(expected_trip)
+    assert {^td, ^vp, stus} = actual_trip
+
+    assert trip_stops(actual_trip) == trip_stops(expected_trip)
+  end
+
+  test "drops predecing stops when prediction involves going back in time" do
+    trip =
+      build_trip([
+        {nil, 1},
+        {2, 3},
+        {4, 10},
+        {9, 12},
+        {15, nil}
+      ])
+
+    filtered_trip = TimeTravel.filter(trip)
+
+    assert [4, 5] == trip_stops(filtered_trip)
+  end
+
+  test "drops predecing stops when multiple instances of time travel are detected" do
+    trip =
+      build_trip([
+        {nil, 1},
+        {2, 3},
+        {4, 10},
+        {9, 12},
+        {15, 20},
+        {19, 25}
+      ])
+
+    filtered_trip = TimeTravel.filter(trip)
+
+    assert [6] == trip_stops(filtered_trip)
+  end
+end

--- a/test/concentrate/group_filter/time_travel_test.exs
+++ b/test/concentrate/group_filter/time_travel_test.exs
@@ -47,7 +47,7 @@ defmodule Concentrate.GroupFilter.TimeTravelTest do
     assert trip_stops(actual_trip) == trip_stops(expected_trip)
   end
 
-  test "drops predecing stops when prediction involves going back in time" do
+  test "drops preceding stops when prediction involves going back in time" do
     trip =
       build_trip([
         {nil, 1},
@@ -62,7 +62,7 @@ defmodule Concentrate.GroupFilter.TimeTravelTest do
     assert [4, 5] == trip_stops(filtered_trip)
   end
 
-  test "drops predecing stops when multiple instances of time travel are detected" do
+  test "drops preceding stops when multiple instances of time travel are detected" do
     trip =
       build_trip([
         {nil, 1},

--- a/test/concentrate/group_filter/time_travel_test.exs
+++ b/test/concentrate/group_filter/time_travel_test.exs
@@ -11,7 +11,7 @@ defmodule Concentrate.GroupFilter.TimeTravelTest do
       start_date: "20190101"
     }
 
-    stus =
+    stop_time_updates =
       timings
       |> Enum.with_index(1)
       |> Enum.map(fn {{arrival, departure}, sequence} ->
@@ -23,11 +23,11 @@ defmodule Concentrate.GroupFilter.TimeTravelTest do
         }
       end)
 
-    {td, [], stus}
+    {td, [], stop_time_updates}
   end
 
-  defp trip_stops({_, _, stus}) do
-    Enum.map(stus, & &1.stop_sequence)
+  defp trip_stops({_, _, stop_time_updates}) do
+    Enum.map(stop_time_updates, & &1.stop_sequence)
   end
 
   test "does not affect linear trips" do
@@ -40,9 +40,9 @@ defmodule Concentrate.GroupFilter.TimeTravelTest do
         {15, nil}
       ])
 
-    {td, vp, stus} = expected_trip
+    {td, vp, stop_time_updates} = expected_trip
     actual_trip = TimeTravel.filter(expected_trip)
-    assert {^td, ^vp, stus} = actual_trip
+    assert {^td, ^vp, stop_time_updates} = actual_trip
 
     assert trip_stops(actual_trip) == trip_stops(expected_trip)
   end

--- a/test/concentrate/stop_time_update_test.exs
+++ b/test/concentrate/stop_time_update_test.exs
@@ -27,7 +27,7 @@ defmodule Concentrate.StopTimeUpdateTest do
   end
 
   describe "Concentrate.Mergeable" do
-    test "takes non-nil values, earliest arrival, latest departure" do
+    test "takes non-nil values, uses arrival/departure times from earliest arrival." do
       first = @stu
 
       second =
@@ -36,7 +36,7 @@ defmodule Concentrate.StopTimeUpdateTest do
           stop_id: "stop",
           stop_sequence: 1,
           arrival_time: 1,
-          departure_time: 4,
+          departure_time: 2,
           track: "track",
           schedule_relationship: :SKIPPED,
           uncertainty: 300
@@ -48,7 +48,7 @@ defmodule Concentrate.StopTimeUpdateTest do
           stop_id: "stop",
           stop_sequence: 1,
           arrival_time: 1,
-          departure_time: 4,
+          departure_time: 2,
           status: "status",
           track: "track",
           schedule_relationship: :SKIPPED,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** 
[🧠 🐛 Don't mix predictions: Multiple sources to Swiftly, same trip](https://app.asana.com/0/584764604969369/1204277338626227/f)
[🧠 🐛 Don't mix predictions: Multiple buses, same trip](https://app.asana.com/0/584764604969369/1204277338626221/f)

This ensures that we are always using times from the same prediction when merging StopTimeUpdates and filters trips that suggest we'll arrive at a later stop before departing a previous one.
