### PR TITLE
Update to cancelled_trip group filter 

### DIFF
--- a/lib/concentrate/group_filter/cancelled_trip.ex
+++ b/lib/concentrate/group_filter/cancelled_trip.ex
@@ -18,11 +18,11 @@ defmodule Concentrate.GroupFilter.CancelledTrip do
       TripDescriptor.schedule_relationship(td) == :CANCELED ->
         cancel_group(group)
 
+      Enum.all?(stop_time_updates, &StopTimeUpdate.skipped?(&1)) ->
+        cancel_group(group)
+
       is_nil(time) ->
         group
-
-      Enum.all?(stop_time_updates, &(StopTimeUpdate.schedule_relationship(&1) == :SKIPPED)) ->
-        cancel_group(group)
 
       is_binary(trip_id) and module.trip_cancelled?(trip_id, time) ->
         cancel_group(group)

--- a/lib/concentrate/group_filter/cancelled_trip.ex
+++ b/lib/concentrate/group_filter/cancelled_trip.ex
@@ -9,7 +9,7 @@ defmodule Concentrate.GroupFilter.CancelledTrip do
   @impl Concentrate.GroupFilter
   def filter(trip_group, module \\ CancelledTrips)
 
-  def filter({%TripDescriptor{} = td, _vps, [stu | _]} = group, module) do
+  def filter({%TripDescriptor{} = td, _vps, [stu | _] = stop_time_updates} = group, module) do
     trip_id = TripDescriptor.trip_id(td)
     route_id = TripDescriptor.route_id(td)
     time = StopTimeUpdate.time(stu)
@@ -20,6 +20,9 @@ defmodule Concentrate.GroupFilter.CancelledTrip do
 
       is_nil(time) ->
         group
+
+      Enum.all?(stop_time_updates, &(StopTimeUpdate.schedule_relationship(&1) == :SKIPPED)) ->
+        cancel_group(group)
 
       is_binary(trip_id) and module.trip_cancelled?(trip_id, time) ->
         cancel_group(group)

--- a/lib/concentrate/stop_time_update.ex
+++ b/lib/concentrate/stop_time_update.ex
@@ -34,6 +34,11 @@ defmodule Concentrate.StopTimeUpdate do
     %{stu | schedule_relationship: :SKIPPED, arrival_time: nil, departure_time: nil, status: nil}
   end
 
+  @spec skipped?(%__MODULE__{}) :: boolean()
+  def skipped?(%__MODULE__{schedule_relationship: schedule_relationship}) do
+    schedule_relationship == :SKIPPED
+  end
+
   defimpl Concentrate.Mergeable do
     def key(%{trip_id: trip_id, stop_sequence: stop_sequence}), do: {trip_id, stop_sequence}
 

--- a/test/concentrate/stop_time_update_test.exs
+++ b/test/concentrate/stop_time_update_test.exs
@@ -10,7 +10,8 @@ defmodule Concentrate.StopTimeUpdateTest do
          arrival_time: 2,
          departure_time: 3,
          status: "status",
-         platform_id: "platform"
+         platform_id: "platform",
+         schedule_relationship: :SCHEDULED
        )
 
   describe "skip/1" do
@@ -23,6 +24,17 @@ defmodule Concentrate.StopTimeUpdateTest do
     test "sets the relationship to SKIPPED" do
       skipped = skip(@stu)
       assert schedule_relationship(skipped) == :SKIPPED
+    end
+  end
+
+  describe "skipped?/1" do
+    test "returns false if stop time update schedule relationship is not skipped" do
+      assert skipped?(@stu) == false
+    end
+
+    test "returns true if stop time update schedule relationship is skipped" do
+      skipped = skip(@stu)
+      assert skipped?(skipped) == true
     end
   end
 


### PR DESCRIPTION
#### Summary of changes

Cancelled trip group filter now filters out trips where all stop updates have SKIPPED status

**Asana Ticket:** [Add trip-level schedule_relationship for canceled bus trips](https://app.asana.com/0/505721188639414/1204778267687026/f)

This change surfaces a trip-level schedule relationship of CANCELED for bus trips where all of the associated stop time updates have been given the SKIPPED status.
