### PR TITLE
chore: remove the removal of blue line predictions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,10 +37,6 @@ config :concentrate,
   ],
   group_filters: [
     {
-      Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates,
-      uncertainties_by_route: %{"Blue" => [120, 360]}
-    },
-    {
       Concentrate.GroupFilter.ScheduledStopTimes,
       # https://github.com/mbta/commuter_rail_boarding/blob/79a493f/config/config.exs#L34-L63
       on_time_statuses: ["All aboard", "Now boarding", "On time", "On Time"]


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] 🧠 Re-enable terminal/reverse trip predictions for Blue Line](https://app.asana.com/0/584764604969369/1204944794413796/f)

Removes the Blue Line filter that was added previously here - https://github.com/mbta/concentrate/pull/277