### PR TITLE
fix: turn off terminal predictions for RL for now

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -60,6 +60,10 @@ config :concentrate,
   ],
   group_filters: [
     {
+      Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates,
+      uncertainties_by_route: %{"Red" => [120, 360]}
+    },
+    {
       Concentrate.GroupFilter.ScheduledStopTimes,
       # https://github.com/mbta/commuter_rail_boarding/blob/79a493f/config/config.exs#L34-L63
       on_time_statuses: ["All aboard", "Now boarding", "On time", "On Time"]


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] 🧠 Temporarily suppress terminal/reverse trip predictions for Red Line in Concentrate](https://app.asana.com/0/505721188639414/1205390570992202/f)

Re-instates the red line config originally added in this PR: https://github.com/mbta/concentrate/pull/277
