### PR TITLE
feat: allow integer vehicle IDs

### DIFF
--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -214,8 +214,18 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
   defp decode_trip_descriptor(%{"trip" => trip} = descriptor) do
     vehicle_id =
       case descriptor do
-        %{"vehicle" => %{"id" => vehicle_id}} -> vehicle_id
-        _ -> nil
+        %{"vehicle" => %{"id" => vehicle_id}} when is_binary(vehicle_id) ->
+          vehicle_id
+
+        %{"vehicle" => %{"id" => vehicle_id}} when is_integer(vehicle_id) ->
+          Logger.warning(fn ->
+            "#{__MODULE__}: treating integer vehicle ID as string: #{inspect(vehicle_id)}"
+          end)
+
+          Integer.to_string(vehicle_id)
+
+        _ ->
+          nil
       end
 
     [

--- a/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
+++ b/test/concentrate/parser/gtfs_realtime_enhanced_test.exs
@@ -303,6 +303,23 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhancedTest do
     end
   end
 
+  test "parses vehicle_id into string and logs warning if int" do
+    map = %{
+      "trip" => %{
+        "trip_id" => "trip",
+        "route_id" => "route"
+      },
+      "vehicle" => %{
+        "id" => 1234
+      },
+      "stop_time_update" => []
+    }
+
+    {[td], log} = with_log(fn -> decode_trip_update(map, Helpers.parse_options([])) end)
+    assert TripDescriptor.vehicle_id(td) == "1234"
+    assert log =~ "treating integer vehicle ID as string: 1234"
+  end
+
   describe "decode_vehicle/3" do
     test "returns nothing if there's an empty map" do
       assert decode_vehicle(%{}, Helpers.parse_options([]), nil) == []


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [allow integer vehicle IDs in concentrate in case they get passed through](https://app.asana.com/0/0/1205504059419471/f)

Logs a warning if an integer vehicle ID is encountered and stringifies it with `Integer.to_string/1`.