### PR TITLE
feat: send partial updates via MQTT sink

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -87,11 +87,14 @@ config :concentrate,
   ],
   encoders: [
     files: [
-      {"TripUpdates.pb", Concentrate.Encoder.TripUpdates},
-      {"TripUpdates.json", Concentrate.Encoder.TripUpdates.JSON},
+      {"TripUpdates.pb", Concentrate.Encoder.TripUpdates,
+       selector: {Concentrate.FeedUpdate, :full_update?, []}},
+      {"TripUpdates.json", Concentrate.Encoder.TripUpdates.JSON,
+       selector: {Concentrate.FeedUpdate, :full_update?, []}},
       {"VehiclePositions.pb", Concentrate.Encoder.VehiclePositions},
       {"VehiclePositions.json", Concentrate.Encoder.VehiclePositions.JSON},
-      {"TripUpdates_enhanced.json", Concentrate.Encoder.TripUpdatesEnhanced},
+      {"TripUpdates_enhanced.json", Concentrate.Encoder.TripUpdatesEnhanced,
+       selector: {Concentrate.FeedUpdate, :full_update?, []}},
       {"VehiclePositions_enhanced.json", Concentrate.Encoder.VehiclePositionsEnhanced}
     ]
   ],

--- a/lib/concentrate.ex
+++ b/lib/concentrate.ex
@@ -175,7 +175,7 @@ defmodule Concentrate do
   end
 
   defp decode_sinks_object(_, acc) do
-    acc
+    Keyword.new(acc)
   end
 
   defp is_possible_env_var(value) do

--- a/lib/concentrate/encoder/producer_consumer.ex
+++ b/lib/concentrate/encoder/producer_consumer.ex
@@ -41,10 +41,14 @@ defmodule Concentrate.Encoder.ProducerConsumer do
 
         _ =
           Logger.debug(fn ->
-            "#{__MODULE__} encoded filename=#{inspect(filename)} time=#{time / 1000}"
+            "#{__MODULE__} encoded filename=#{inspect(filename)} time=#{time / 1000} partial?=#{FeedUpdate.partial?(update)}"
           end)
 
-        {filename, encoded}
+        if FeedUpdate.partial?(update) do
+          {filename, encoded, partial?: true}
+        else
+          {filename, encoded}
+        end
       end
 
     {:noreply, responses, state, :hibernate}

--- a/lib/concentrate/feed_update.ex
+++ b/lib/concentrate/feed_update.ex
@@ -17,6 +17,11 @@ defmodule Concentrate.FeedUpdate do
     super([update_count: update_count] ++ opts)
   end
 
+  @doc "Inverse of partial?"
+  def full_update?(%__MODULE__{} = update) do
+    not partial?(update)
+  end
+
   defimpl Enumerable do
     def count(update) do
       {:ok, update.update_count}

--- a/lib/concentrate/mergeable.ex
+++ b/lib/concentrate/mergeable.ex
@@ -15,4 +15,11 @@ defprotocol Concentrate.Mergeable do
   @spec merge(mergeable, mergeable) :: mergeable
         when mergeable: struct
   def merge(first, second)
+
+  @doc """
+  Returns a list of additional {module, key} to use when returning
+  partial merge items.
+  """
+  @spec related_keys(struct) :: [{module, term}]
+  def related_keys(merge)
 end

--- a/lib/concentrate/sink/filesystem.ex
+++ b/lib/concentrate/sink/filesystem.ex
@@ -4,6 +4,16 @@ defmodule Concentrate.Sink.Filesystem do
   """
   require Logger
 
+  def start_link(opts, file_data)
+
+  def start_link(opts, {filename, body, file_opts}) do
+    if file_opts[:partial?] do
+      :ignore
+    else
+      start_link(opts, {filename, body})
+    end
+  end
+
   def start_link(opts, {filename, body}) do
     directory = Keyword.fetch!(opts, :directory)
 

--- a/lib/concentrate/sink/s3.ex
+++ b/lib/concentrate/sink/s3.ex
@@ -7,13 +7,23 @@ defmodule Concentrate.Sink.S3 do
 
   @ex_aws Application.compile_env(:concentrate, [:sink_s3, :ex_aws], ExAws)
 
-  def start_link(opts, file_data) do
+  def start_link(opts, file_data)
+
+  def start_link(opts, {filename, body, file_opts}) do
+    if file_opts[:partial?] do
+      :ignore
+    else
+      start_link(opts, {filename, body})
+    end
+  end
+
+  def start_link(opts, {filename, body}) do
     opts = Concentrate.unwrap_values(opts)
     bucket = Keyword.fetch!(opts, :bucket)
     prefix = Keyword.get(opts, :prefix, "")
     acl = Keyword.get(opts, :acl, :public_read)
     state = %{bucket: bucket, prefix: prefix, acl: acl}
-    Task.start_link(__MODULE__, :upload_to_s3, [file_data, state])
+    Task.start_link(__MODULE__, :upload_to_s3, [{filename, body}, state])
   end
 
   def upload_to_s3({filename, body}, state) do

--- a/lib/concentrate/stop_time_update.ex
+++ b/lib/concentrate/stop_time_update.ex
@@ -44,6 +44,8 @@ defmodule Concentrate.StopTimeUpdate do
 
     def key(%{trip_id: trip_id, stop_sequence: stop_sequence}), do: {trip_id, stop_sequence}
 
+    def related_keys(_), do: []
+
     def merge(first, second) do
       time_stu =
         if Concentrate.StopTimeUpdate.time(first) <= Concentrate.StopTimeUpdate.time(second),

--- a/lib/concentrate/trip_descriptor.ex
+++ b/lib/concentrate/trip_descriptor.ex
@@ -36,6 +36,8 @@ defmodule Concentrate.TripDescriptor do
   defimpl Concentrate.Mergeable do
     def key(%{trip_id: trip_id}), do: trip_id
 
+    def related_keys(_), do: []
+
     def merge(first, second) do
       if {first.start_date, first.start_time} > {second.start_date, second.start_time} do
         do_merge(first, second)

--- a/lib/concentrate/vehicle_position.ex
+++ b/lib/concentrate/vehicle_position.ex
@@ -57,6 +57,10 @@ defmodule Concentrate.VehiclePosition do
   defimpl Concentrate.Mergeable do
     def key(%{id: id}), do: id
 
+    def related_keys(%{trip_id: trip_id}) do
+      [{Concentrate.TripDescriptor, trip_id}]
+    end
+
     @doc """
     Merging VehiclePositions takes the latest position for a given vehicle.
     """

--- a/test/concentrate/sink/mqtt_test.exs
+++ b/test/concentrate/sink/mqtt_test.exs
@@ -44,6 +44,20 @@ defmodule Concentrate.Sink.MqttTest do
 
       assert :zlib.gunzip(message.payload) == body
     end
+
+    test "can write a partial feed, gzip-encoded", %{config: config} do
+      filename = "file_#{System.unique_integer()}"
+      body = "#{System.unique_integer()}"
+
+      start_with_events(config, [{filename, body, partial?: true}])
+
+      expected_topic = "#{config[:prefix]}#{filename}"
+
+      assert_receive {:message, _, message = %EmqttFailover.Message{topic: ^expected_topic}},
+                     5_000
+
+      assert :zlib.gunzip(message.payload) == body
+    end
   end
 
   defp start_with_events(config, events) do

--- a/test/concentrate_test.exs
+++ b/test/concentrate_test.exs
@@ -100,6 +100,7 @@ defmodule ConcentrateTest do
 
       assert config[:gtfs][:url] == "gtfs_url"
       assert config[:alerts][:url] == "alerts_url"
+      assert is_list(config[:sinks])
       assert is_list(config[:sinks][:s3])
       assert config[:sinks][:s3][:bucket] == "s3-bucket"
       assert config[:sinks][:s3][:prefix] == "bucket_prefix"
@@ -126,7 +127,7 @@ defmodule ConcentrateTest do
       assert config[:sources][:gtfs_realtime] == %{}
       assert config[:sources][:gtfs_realtime_enhanced] == %{}
       assert config[:gtfs] == nil
-      assert config[:sinks] == %{}
+      assert config[:sinks] == []
     end
 
     test "gtfs_realtime sources can have additional route configuration" do

--- a/test/support/test_mergeable.ex
+++ b/test/support/test_mergeable.ex
@@ -20,14 +20,26 @@ defmodule Concentrate.TestMergeable do
   def mergeables do
     # get a keyword list of integers, filter out duplicate keys, then create
     # mergeables
-    StreamData.integer()
-    |> StreamData.keyword_of()
-    |> StreamData.map(fn list -> Enum.uniq_by(list, &elem(&1, 0)) end)
-    |> StreamData.map(fn list -> Enum.map(list, fn {k, v} -> new(k, v) end) end)
+    gen all(
+          length <- integer(0..9),
+          keys <- uniq_list_of(key(), length: length),
+          values <- list_of(integer(), length: length)
+        ) do
+      keys
+      |> Enum.zip(values)
+      |> Enum.map(fn {k, v} -> new(k, v) end)
+    end
+  end
+
+  defp key do
+    StreamData.string(:alphanumeric, length: 1)
+    |> StreamData.map(&String.to_atom/1)
   end
 
   defimpl Concentrate.Mergeable do
     def key(%{key: key}), do: key
+
+    def related_keys(_), do: []
 
     def merge(first, second) do
       value =


### PR DESCRIPTION
#### Summary of changes

Sends DIFFERENTIAL updates via MQTT, to reduce latency on processing Vehicle Positions.

**Asana Ticket:** [Concentrate: avoid batching updates in the MQTT -> MergeTable -> MQTT pipeline](https://app.asana.com/0/1205365039348894/1205365039348911/f)