### PR TITLE
Revert "fix: turn off terminal predictions for RL for now"

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -60,10 +60,6 @@ config :concentrate,
   ],
   group_filters: [
     {
-      Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates,
-      uncertainties_by_route: %{"Red" => [120, 360]}
-    },
-    {
       Concentrate.GroupFilter.ScheduledStopTimes,
       # https://github.com/mbta/commuter_rail_boarding/blob/79a493f/config/config.exs#L34-L63
       on_time_statuses: ["All aboard", "Now boarding", "On time", "On Time"]


### PR DESCRIPTION
Reverts mbta/concentrate#300