### PR TITLE
fix(mqtt): reconnect more quickly

### DIFF
--- a/lib/concentrate/producer/mqtt.ex
+++ b/lib/concentrate/producer/mqtt.ex
@@ -78,6 +78,7 @@ defmodule Concentrate.Producer.Mqtt do
     [
       configs: configs,
       client_id: EmqttFailover.client_id(prefix: "cntrt-prd"),
+      backoff: {1_000, 60_000, :jitter},
       handler: handler,
       backoff: Keyword.get(opts, :backoff)
     ]

--- a/lib/concentrate/sink/mqtt.ex
+++ b/lib/concentrate/sink/mqtt.ex
@@ -18,6 +18,7 @@ defmodule Concentrate.Sink.Mqtt do
     {:ok, client} =
       EmqttFailover.Connection.start_link(
         client_id: EmqttFailover.client_id(prefix: "cntrt-snk"),
+        backoff: {1_000, 60_000, :jitter},
         configs: configs,
         handler: {EmqttFailover.ConnectionHandler.Parent, parent: self()}
       )


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [test handling of failures/restarts with a multi-AZ broker](https://app.asana.com/0/584764604969369/1205632203703839/f)

The default is to reconnect starting at 5 seconds, expontentially going up to 5 minutes. This starts at 1 second and goes up to 1 minute.