### PR TITLE
feat: improve merging of VehiclePosition.status()

### DIFF
--- a/lib/concentrate/encoder/vehicle_positions.ex
+++ b/lib/concentrate/encoder/vehicle_positions.ex
@@ -73,7 +73,7 @@ defmodule Concentrate.Encoder.VehiclePositions do
       position: position,
       stop_id: VehiclePosition.stop_id(vp),
       current_stop_sequence: VehiclePosition.stop_sequence(vp),
-      current_status: VehiclePosition.status(vp),
+      current_status: VehiclePosition.status(vp) || :IN_TRANSIT_TO,
       timestamp: VehiclePosition.last_updated_truncated(vp),
       occupancy_status: VehiclePosition.occupancy_status(vp),
       occupancy_percentage: VehiclePosition.occupancy_percentage(vp),

--- a/lib/concentrate/encoder/vehicle_positions_enhanced.ex
+++ b/lib/concentrate/encoder/vehicle_positions_enhanced.ex
@@ -69,7 +69,7 @@ defmodule Concentrate.Encoder.VehiclePositionsEnhanced do
       "position" => position,
       "stop_id" => VehiclePosition.stop_id(vp),
       "current_stop_sequence" => VehiclePosition.stop_sequence(vp),
-      "current_status" => VehiclePosition.status(vp),
+      "current_status" => VehiclePosition.status(vp) || "IN_TRANSIT_TO",
       "timestamp" => VehiclePosition.last_updated_truncated(vp),
       "occupancy_status" => VehiclePosition.occupancy_status(vp),
       "occupancy_percentage" => VehiclePosition.occupancy_percentage(vp),

--- a/lib/concentrate/vehicle_position.ex
+++ b/lib/concentrate/vehicle_position.ex
@@ -21,7 +21,7 @@ defmodule Concentrate.VehiclePosition do
     :occupancy_status,
     :occupancy_percentage,
     :multi_carriage_details,
-    status: :IN_TRANSIT_TO
+    :status
   ])
 
   defmodule Consist do
@@ -92,6 +92,7 @@ defmodule Concentrate.VehiclePosition do
           bearing: first_value(second.bearing, first.bearing),
           speed: first_value(second.speed, first.speed),
           odometer: first_value(second.odometer, first.odometer),
+          status: first_value(second.status, first.status),
           stop_sequence: first_value(second.stop_sequence, first.stop_sequence),
           occupancy_status: first_value(second.occupancy_status, first.occupancy_status),
           occupancy_percentage:

--- a/test/concentrate/encoder/vehicle_positions_enhanced_test.exs
+++ b/test/concentrate/encoder/vehicle_positions_enhanced_test.exs
@@ -23,13 +23,20 @@ defmodule Concentrate.Encoder.VehiclePositionsEnhancedTest do
     test "includes consist/occupancy data if present" do
       data = [
         TripDescriptor.new(trip_id: "one", vehicle_id: "y1"),
-        VehiclePosition.new(trip_id: "one", id: "y1", latitude: 1, longitude: 1),
+        VehiclePosition.new(
+          trip_id: "one",
+          id: "y1",
+          latitude: 1,
+          longitude: 1,
+          status: :IN_TRANSIT_TO
+        ),
         TripDescriptor.new(trip_id: "two", vehicle_id: "y2"),
         VehiclePosition.new(
           trip_id: "two",
           id: "y2",
           latitude: 2,
           longitude: 2,
+          status: :IN_TRANSIT_TO,
           occupancy_status: :FULL,
           occupancy_percentage: 101,
           consist: [

--- a/test/concentrate/encoder/vehicle_positions_test.exs
+++ b/test/concentrate/encoder/vehicle_positions_test.exs
@@ -22,8 +22,14 @@ defmodule Concentrate.Encoder.VehiclePositionsTest do
     test "can handle a vehicle w/o a trip" do
       data = [
         trip = TripDescriptor.new(trip_id: "trip"),
-        vehicle = VehiclePosition.new(latitude: 1.0, longitude: 1.0),
-        vehicle_no_trip = VehiclePosition.new(trip_id: "trip", latitude: 2.0, longitude: 2.0)
+        vehicle = VehiclePosition.new(latitude: 1.0, longitude: 1.0, status: :IN_TRANSIT_TO),
+        vehicle_no_trip =
+          VehiclePosition.new(
+            trip_id: "trip",
+            latitude: 2.0,
+            longitude: 2.0,
+            status: :IN_TRANSIT_TO
+          )
       ]
 
       # the trip and trip vehicle are re-arranged in the output
@@ -54,7 +60,14 @@ defmodule Concentrate.Encoder.VehiclePositionsTest do
     end
 
     test "vehicles with a non-matching trip ID generate a fake TripDescriptor" do
-      data = [VehiclePosition.new(trip_id: "trip", latitude: 1.0, longitude: 1.0)]
+      data = [
+        VehiclePosition.new(
+          trip_id: "trip",
+          latitude: 1.0,
+          longitude: 1.0,
+          status: :IN_TRANSIT_TO
+        )
+      ]
 
       assert round_trip(data) ==
                [TripDescriptor.new(trip_id: "trip", schedule_relationship: :UNSCHEDULED)] ++ data
@@ -71,7 +84,12 @@ defmodule Concentrate.Encoder.VehiclePositionsTest do
 
       assert [
                TripDescriptor.new(trip_id: "1"),
-               VehiclePosition.new(trip_id: "1", latitude: 1.0, longitude: 1.0)
+               VehiclePosition.new(
+                 trip_id: "1",
+                 latitude: 1.0,
+                 longitude: 1.0,
+                 status: :IN_TRANSIT_TO
+               )
              ] == decoded
     end
 
@@ -94,11 +112,26 @@ defmodule Concentrate.Encoder.VehiclePositionsTest do
 
       assert [
                TripDescriptor.new(trip_id: "1"),
-               VehiclePosition.new(trip_id: "1", latitude: 1.0, longitude: 1.0),
+               VehiclePosition.new(
+                 trip_id: "1",
+                 latitude: 1.0,
+                 longitude: 1.0,
+                 status: :IN_TRANSIT_TO
+               ),
                TripDescriptor.new(trip_id: "2"),
-               VehiclePosition.new(trip_id: "2", latitude: 1.0, longitude: 1.0),
+               VehiclePosition.new(
+                 trip_id: "2",
+                 latitude: 1.0,
+                 longitude: 1.0,
+                 status: :IN_TRANSIT_TO
+               ),
                TripDescriptor.new(trip_id: "3"),
-               VehiclePosition.new(trip_id: "3", latitude: 1.0, longitude: 1.0)
+               VehiclePosition.new(
+                 trip_id: "3",
+                 latitude: 1.0,
+                 longitude: 1.0,
+                 status: :IN_TRANSIT_TO
+               )
              ] == decoded
     end
 
@@ -110,6 +143,7 @@ defmodule Concentrate.Encoder.VehiclePositionsTest do
           id: "y2",
           latitude: 2,
           longitude: 2,
+          status: :IN_TRANSIT_TO,
           occupancy_status: :FULL,
           occupancy_percentage: 101
         )

--- a/test/concentrate/vehicle_position_test.exs
+++ b/test/concentrate/vehicle_position_test.exs
@@ -26,6 +26,25 @@ defmodule Concentrate.VehiclePositionTest do
       end
     end
 
+    test "merge/2 merges the status/stop_sequence data" do
+      first =
+        new(last_updated: 1, latitude: 1, longitude: 1, status: :STOPPED_AT, stop_sequence: 3)
+
+      second = new(last_updated: 2, latitude: 2, longitude: 2)
+
+      expected =
+        new(
+          last_updated: 2,
+          latitude: 2,
+          longitude: 2,
+          status: :STOPPED_AT,
+          stop_sequence: 3
+        )
+
+      assert Mergeable.merge(first, second) == expected
+      assert Mergeable.merge(second, first) == expected
+    end
+
     test "merge/2 merges the occupancy status information" do
       first = new(last_updated: 1, latitude: 1, longitude: 1, occupancy_status: :MANY_SEATS_FULL)
       second = new(last_updated: 2, latitude: 2, longitude: 2, occupancy_percentage: 50)


### PR DESCRIPTION
Previously, we'd always take the status from the second VehiclePosition. For higher-frequency feeds, this would likely always mean `IN_TRANSIT_TO`. Now, we don't set a default except when encoding. This allows us to take a value from a earlier update.

#### Summary of changes

**Asana Ticket:** [do we keep STOPPED_AT when merging?](https://app.asana.com/0/1205365039348894/1205645288310907/f)
