### PR TITLE
feat: allow configuring which Sinks accept FileTap files

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -110,7 +110,8 @@ Concentrate can be configured either by updating `config/config.exs` file, or by
         }
       },
       "file_tap": {
-        "enabled": true
+        "enabled": true,
+        "sinks": ["s3"]
       }
     }
 

--- a/lib/concentrate.ex
+++ b/lib/concentrate.ex
@@ -109,7 +109,16 @@ defmodule Concentrate do
 
   defp decode_json_key_value({"file_tap", opts}) do
     if Map.get(opts, "enabled") do
-      [file_tap: [enabled?: true]]
+      sink_opts =
+        case opts do
+          %{"sinks" => sinks} when is_list(sinks) ->
+            [sinks: Enum.map(sinks, &String.to_existing_atom/1)]
+
+          _ ->
+            []
+        end
+
+      [file_tap: [enabled?: true] ++ sink_opts]
     else
       []
     end

--- a/test/concentrate/supervisor/pipeline_test.exs
+++ b/test/concentrate/supervisor/pipeline_test.exs
@@ -27,7 +27,53 @@ defmodule Concentrate.Supervisor.PipelineTest do
 
       actual = children(config)
 
-      assert length(actual) == 9
+      assert length(actual) == 8
+    end
+
+    test "enables file_tap with all sinks by default" do
+      config = [
+        sources: [],
+        source_reporters: [],
+        reporters: [],
+        encoders: [files: [{"filename", :encoder_module}]],
+        sinks: [filesystem: [directory: "/tmp"]],
+        file_tap: [enabled?: true]
+      ]
+
+      actual = children(config)
+
+      assert {Concentrate.Producer.FileTap, [enabled?: true]} =
+               List.keyfind(actual, Concentrate.Producer.FileTap, 0)
+
+      assert {Concentrate.Sink.Supervisor,
+              [config: [filesystem: _], sources: [Concentrate.Producer.FileTap, :encoder_module]]} =
+               List.keyfind(actual, Concentrate.Sink.Supervisor, 0)
+    end
+
+    test "enables file_tap with some sinks if configured" do
+      config = [
+        sources: [],
+        source_reporters: [],
+        reporters: [],
+        encoders: [files: [{"filename", :encoder_module}]],
+        sinks: [filesystem: [directory: "/tmp"], s3: []],
+        file_tap: [enabled?: true, sinks: [:filesystem]]
+      ]
+
+      actual = children(config)
+
+      assert {Concentrate.Producer.FileTap, _} =
+               List.keyfind(actual, Concentrate.Producer.FileTap, 0)
+
+      assert [
+               {Concentrate.Sink.Supervisor,
+                [
+                  config: [filesystem: _],
+                  sources: [Concentrate.Producer.FileTap, :encoder_module]
+                ]},
+               {Concentrate.Sink.Supervisor, [config: [s3: _], sources: [:encoder_module]]}
+             ] =
+               Enum.filter(actual, fn value -> match?({Concentrate.Sink.Supervisor, _}, value) end)
     end
 
     test "correctly passes parse options to the parser" do

--- a/test/concentrate_test.exs
+++ b/test/concentrate_test.exs
@@ -78,7 +78,8 @@ defmodule ConcentrateTest do
     }
   },
   "file_tap": {
-    "enabled": true
+    "enabled": true,
+    "sinks": ["s3"]
   }
 }
       )
@@ -115,6 +116,7 @@ defmodule ConcentrateTest do
       assert config[:sinks][:mqtt][:username] == "user"
 
       assert config[:file_tap][:enabled?]
+      assert config[:file_tap][:sinks] == [:s3]
     end
 
     test "missing keys aren't configured" do


### PR DESCRIPTION
FileTap is responsible for logging the files which went into Concentrate. When we only had a single S3 sink, it was easy to send all the FileTap files to the same sink. With the introduction of MQTT, we don't want to send the FileTap files to the MQTT broker, so we need to add a bit of optional configuration about which sinks accept the FileTap files.

See also mbta/devops#1289

**Asana Ticket:** [Concentrate: don't send FileTap files to the MQTT sink](https://app.asana.com/0/1205365039348894/1205748776837980/f)