### PR TITLE
feat: log when VehiclePositions move backwards in time

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -51,7 +51,7 @@ jobs:
         mix local.hex --force
         mix deps.get
     - name: Compile (warnings as errors)
-      run: mix compile --force
+      run: mix compile --force --warnings-as-errors
     - name: Check formatting
       run: mix format --check-formatted
     - name: Credo

--- a/config/config.exs
+++ b/config/config.exs
@@ -83,7 +83,8 @@ config :concentrate,
     Concentrate.Reporter.VehicleLatency,
     Concentrate.Reporter.StopTimeUpdateLatency,
     Concentrate.Reporter.Latency,
-    Concentrate.Reporter.TimeTravel
+    Concentrate.Reporter.TimeTravel,
+    Concentrate.Reporter.VehicleTimeTravel
   ],
   encoders: [
     files: [

--- a/lib/concentrate/reporter/vehicle_time_travel.ex
+++ b/lib/concentrate/reporter/vehicle_time_travel.ex
@@ -1,0 +1,44 @@
+defmodule Concentrate.Reporter.VehicleTimeTravel do
+  @moduledoc """
+  Reports vehicles where the timestamp goes back in time.
+  """
+  require Logger
+  alias Concentrate.VehiclePosition
+
+  @behaviour Concentrate.Reporter
+
+  @impl Concentrate.Reporter
+  def init do
+    %{}
+  end
+
+  @impl Concentrate.Reporter
+  def log(groups, vehicle_timestamps) do
+    vehicle_timestamps = Enum.reduce(groups, vehicle_timestamps, &log_group/2)
+    {[], vehicle_timestamps}
+  end
+
+  defp log_group({_td, vps, _stus}, acc) do
+    Enum.reduce(vps, acc, &log_vehicle/2)
+  end
+
+  defp log_vehicle(vp, acc) do
+    vehicle_id = VehiclePosition.id(vp)
+    timestamp = VehiclePosition.last_updated(vp)
+    old_timestamp = Map.get(acc, vehicle_id)
+
+    if timestamp && old_timestamp && old_timestamp > timestamp do
+      trip_id = VehiclePosition.trip_id(vp)
+
+      Logger.warning(
+        "event=vehicle_time_travel vehicle_id=#{vehicle_id} trip_id=#{trip_id} later=#{old_timestamp} earlier=#{timestamp}"
+      )
+    end
+
+    if timestamp do
+      Map.put(acc, vehicle_id, timestamp)
+    else
+      acc
+    end
+  end
+end

--- a/lib/concentrate/source_reporter/basic.ex
+++ b/lib/concentrate/source_reporter/basic.ex
@@ -14,10 +14,12 @@ defmodule Concentrate.SourceReporter.Basic do
   def log(update, state) do
     count = Enum.count(update)
     partial? = FeedUpdate.partial?(update)
+    timestamp = FeedUpdate.timestamp(update)
 
     stats = [
       count: count,
-      partial?: partial?
+      partial?: partial?,
+      timestamp: timestamp
     ]
 
     {stats, state}

--- a/test/concentrate/reporter/vehicle_time_travel_test.exs
+++ b/test/concentrate/reporter/vehicle_time_travel_test.exs
@@ -1,0 +1,71 @@
+defmodule Concentrate.Reporter.VehicleTimeTravelTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Concentrate.Reporter.VehicleTimeTravel
+  alias Concentrate.{TripDescriptor, VehiclePosition}
+
+  setup do
+    %{state: VehicleTimeTravel.init()}
+  end
+
+  describe "log/2" do
+    test "logs an event if a vehicle has a timestamp which goes back in time", %{state: state} do
+      check all(group1 <- group(), group2 <- group()) do
+        log =
+          ExUnit.CaptureLog.capture_log(fn -> VehicleTimeTravel.log([group1, group2], state) end)
+
+        case {group1, group2} do
+          {{_, [%{id: vehicle_id, last_updated: t1} = vp1], _},
+           {_, [%{id: vehicle_id, last_updated: t2} = vp2], _}}
+          when t1 > t2 ->
+            assert log =~ "event=vehicle_time_travel"
+            assert log =~ "vehicle_id=#{vehicle_id}"
+            assert log =~ "trip_id=#{VehiclePosition.trip_id(vp2)}"
+            assert log =~ "later=#{VehiclePosition.last_updated(vp1)}"
+            assert log =~ "earlier=#{VehiclePosition.last_updated(vp2)}"
+
+          _ ->
+            refute log =~ "event=vehicle_time_travel"
+        end
+      end
+    end
+  end
+
+  defp group do
+    gen all(
+          trip_id <- trip_id(),
+          vehicle_ids <- list_of(vehicle_id(), max_length: 1),
+          timestamp <- integer(0..2)
+        ) do
+      td = TripDescriptor.new(trip_id: trip_id)
+
+      vps =
+        for vehicle_id <- vehicle_ids do
+          VehiclePosition.new(
+            id: vehicle_id,
+            latitude: 0,
+            longitude: 0,
+            last_updated: timestamp,
+            trip_id: trip_id
+          )
+        end
+
+      stus = []
+      {td, vps, stus}
+    end
+  end
+
+  def trip_id do
+    ["trip_a", "trip_b"]
+    |> Enum.map(&constant/1)
+    |> one_of
+  end
+
+  def vehicle_id do
+    ["v1", "v2"]
+    |> Enum.map(&constant/1)
+    |> one_of
+  end
+end

--- a/test/concentrate/source_reporter/basic_test.exs
+++ b/test/concentrate/source_reporter/basic_test.exs
@@ -10,10 +10,11 @@ defmodule Concentrate.SourceReporter.BasicTest do
       update =
         Concentrate.FeedUpdate.new(
           url: "url",
+          timestamp: 123,
           updates: [1, 2, 3]
         )
 
-      assert {[count: 3, partial?: false], _state} = log(update, state)
+      assert {[count: 3, partial?: false, timestamp: 123], _state} = log(update, state)
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Green Line trains going backwards in time](https://app.asana.com/0/1204137169527258/1205763132199440/f)

Logs when vehicles have a timestamp earlier than the current timestamp.
