### PR TITLE
fix: don't include non-revenue trips in feeds

### DIFF
--- a/lib/concentrate/encoder/gtfs_realtime_helpers.ex
+++ b/lib/concentrate/encoder/gtfs_realtime_helpers.ex
@@ -140,6 +140,16 @@ defmodule Concentrate.Encoder.GTFSRealtimeHelpers do
   def schedule_relationship(:SCHEDULED), do: nil
   def schedule_relationship(relationship), do: relationship
 
+  @doc """
+  Returns true if the group is non-revenue
+  """
+  def is_non_revenue?({td, _, stus} = _group) do
+    td &&
+      td.trip_id &&
+      String.starts_with?(td.trip_id, "NONREV") &&
+      Enum.all?(stus, &(&1.schedule_relationship == :SKIPPED))
+  end
+
   defp group_by_trip_id(%TripDescriptor{} = td, map) do
     if trip_id = TripDescriptor.trip_id(td) do
       Map.update(map, trip_id, {td, [], []}, &add_trip_descriptor(&1, td))

--- a/lib/concentrate/encoder/trip_updates.ex
+++ b/lib/concentrate/encoder/trip_updates.ex
@@ -8,6 +8,8 @@ defmodule Concentrate.Encoder.TripUpdates do
 
   @impl Concentrate.Encoder
   def encode_groups(groups, opts \\ []) when is_list(groups) do
+    groups = Enum.reject(groups, &is_non_revenue?/1)
+
     message = %{
       header: feed_header(opts),
       entity: trip_update_feed_entity(groups, &build_stop_time_update/1)

--- a/lib/concentrate/encoder/trip_updates_enhanced.ex
+++ b/lib/concentrate/encoder/trip_updates_enhanced.ex
@@ -8,6 +8,8 @@ defmodule Concentrate.Encoder.TripUpdatesEnhanced do
 
   @impl Concentrate.Encoder
   def encode_groups(groups, opts \\ []) when is_list(groups) do
+    groups = Enum.reject(groups, &is_non_revenue?/1)
+
     message = %{
       header: feed_header(opts),
       entity: trip_update_feed_entity(groups, &build_stop_time_update/1, &enhanced_data/1)

--- a/test/concentrate/encoder/trip_updates_enhanced_test.exs
+++ b/test/concentrate/encoder/trip_updates_enhanced_test.exs
@@ -126,5 +126,49 @@ defmodule Concentrate.Encoder.TripUpdatesEnhancedTest do
                ]
              } = encoded
     end
+
+    test "Non-revenue trips with skipped stops are dropped" do
+      parsed = [
+        TripDescriptor.new(trip_id: "NONREV-trip", route_id: "route", direction_id: 0),
+        StopTimeUpdate.new(
+          trip_id: "NONREV-trip",
+          stop_id: "stop",
+          schedule_relationship: :SKIPPED
+        )
+      ]
+
+      encoded = Jason.decode!(encode_groups(group(parsed)))
+
+      assert %{
+               "entity" => []
+             } = encoded
+    end
+
+    test "Non-revenue trips with unskipped stops are retained" do
+      parsed = [
+        TripDescriptor.new(trip_id: "NONREV-trip", route_id: "route", direction_id: 0),
+        StopTimeUpdate.new(
+          trip_id: "NONREV-trip",
+          stop_id: "stop",
+          schedule_relationship: :SCHEDULED
+        )
+      ]
+
+      encoded = Jason.decode!(encode_groups(group(parsed)))
+
+      assert %{
+               "entity" => [
+                 %{
+                   "trip_update" => %{
+                     "trip" => %{
+                       "route_id" => "route",
+                       "direction_id" => 0
+                     },
+                     "stop_time_update" => [%{"stop_id" => "stop"}]
+                   }
+                 }
+               ]
+             } = encoded
+    end
   end
 end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🧠🚫💰 Surface non-revenue train information through our public-facing data feeds/API](https://app.asana.com/0/505721188639414/1205761861495473/f)

Note: We will shortly want to start exposing non-revenue trips in the enhanced feed. This implementation is chosen to make that update trivial.
