### PR TITLE
ci: update deploy name and environment from "production" to "prod"

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,4 +1,4 @@
-name: Deploy to Production
+name: Deploy to Prod
 
 on: workflow_dispatch
 
@@ -9,8 +9,8 @@ jobs:
     permissions:
       id-token: write
       contents: read    
-    environment: production
-    concurrency: production
+    environment: prod
+    concurrency: prod
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** No ticket

This looks like it only affects naming within github actions. The elixir config is already `config/prod.exs`

Update deploy name and environment from "production" to "prod" to match other repos (rtr etc)