### PR TITLE
fix: disable SASL logs

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -3,7 +3,6 @@ import Config
 config :sasl, errlog_type: :error
 
 config :logger,
-  handle_sasl_reports: true,
   level: :info,
   backends: [:console, Sentry.LoggerBackend]
 

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Concentrate.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger | env_applications(Mix.env())],
+      extra_applications: env_applications(Mix.env()) ++ [:logger],
       mod: {Concentrate, []}
     ]
   end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] 🧠 disable noisy SASL logging](https://app.asana.com/0/584764604969369/1207488587291495/f)

SASL logging is deprecated as of Erlang 21: https://www.erlang.org/doc/apps/sasl/error_logging. This functionality was removed from commuter_rail_boarding back in 2022: https://github.com/mbta/commuter_rail_boarding/commit/735b16e436b1b5dba0b18f6230739159da4f55a8. It mostly generates a lot of noise in the logs when starting TLS connections which confuses searching for errors.