### PR TITLE
GTFS.Routes subscribed to :gtfs_producer

### DIFF
--- a/lib/concentrate/gtfs/supervisor.ex
+++ b/lib/concentrate/gtfs/supervisor.ex
@@ -21,6 +21,7 @@ defmodule Concentrate.GTFS.Supervisor do
               name: :gtfs_producer
             }
           },
+          {Concentrate.GTFS.Routes, subscribe_to: [:gtfs_producer]},
           {Concentrate.GTFS.Trips, subscribe_to: [:gtfs_producer]},
           {Concentrate.GTFS.Stops, subscribe_to: [:gtfs_producer]},
           {Concentrate.GTFS.StopTimes, subscribe_to: [:gtfs_producer]}


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Bus trips with block waivers not marked as cancelled](https://app.asana.com/0/1204137169527258/1208580923116010)

Ensure the routes table is populated with route records so that bus trips with block waivers are cancelled.

Debugging bus trips that had skipped stops but weren't marked as cancelled, @boringcactus observed that it is expected for them to be marked as cancelled [here](https://github.com/mbta/concentrate/blob/981d82250adff8080091d3afc743df6e9b62576d/lib/concentrate/group_filter/cancelled_trip.ex#L52). It seemed the `bus_block_waiver?` check might be failing. I observed no logs in Splunk from `Concentrate.GTFS.Routes` as expected [here](https://github.com/mbta/concentrate/blob/981d82250adff8080091d3afc743df6e9b62576d/lib/concentrate/gtfs/routes.ex#L42), and figured it was missing from the supervisor.

## Testing
* Confirmed Splunk log that GTFS.Routes table is updated as expected
`7deb6bd8b11a 2024-10-21T14:39:00.577 [info]  Elixir.Concentrate.GTFS.Routes: updated with 382 records`

Looking at a bus trip with a block waiver in prod marked as skipped:
```
{
      "attributes": {
        "arrival_time": null,
        "arrival_uncertainty": null,
        "departure_time": null,
        "departure_uncertainty": null,
        "direction_id": 1,
        "last_trip": false,
        "revenue": "REVENUE",
        "schedule_relationship": "SKIPPED",
        "status": null,
        "stop_sequence": 1,
        "update_type": null
      },
      "id": "prediction-64463790-110-1-1",
      ...
```
Same bus trip in dev-blue with this change applied:
```
    {
      "attributes": {
        "arrival_time": null,
        "arrival_uncertainty": null,
        "departure_time": null,
        "departure_uncertainty": null,
        "direction_id": 1,
        "last_trip": false,
        "revenue": "REVENUE",
        "schedule_relationship": "CANCELLED",
        "status": null,
        "stop_sequence": 1,
        "update_type": null
      },
      "id": "prediction-64463790-110-1-1",
      ...
```