### PR TITLE
Closed stop on route

### DIFF
--- a/lib/concentrate/filter/alert/closed_stops.ex
+++ b/lib/concentrate/filter/alert/closed_stops.ex
@@ -52,7 +52,10 @@ defmodule Concentrate.Filter.Alert.ClosedStops do
   defp closed_stop_entities(alert) do
     cond do
       Alert.effect(alert) == :NO_SERVICE ->
-        for entity <- Alert.informed_entity(alert), not is_nil(InformedEntity.stop_id(entity)) do
+        for entity <- Alert.informed_entity(alert),
+            not is_nil(InformedEntity.stop_id(entity)),
+            "BOARD" in InformedEntity.activities(entity),
+            "EXIT" in InformedEntity.activities(entity) do
           entity
         end
 

--- a/lib/concentrate/filter/alert/closed_stops.ex
+++ b/lib/concentrate/filter/alert/closed_stops.ex
@@ -13,8 +13,8 @@ defmodule Concentrate.Filter.Alert.ClosedStops do
     GenStage.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
-  @spec stop_closed_for(String.t(), integer) :: [Alert.InformedEntity.t()]
-  def stop_closed_for(stop_id, timestamp) when is_binary(stop_id) do
+  @spec stop_closed_for(String.t(), String.t(), integer) :: [Alert.InformedEntity.t()]
+  def stop_closed_for(stop_id, _route_id, timestamp) when is_binary(stop_id) do
     TimeTable.date_overlaps(@table, stop_id, timestamp)
   end
 

--- a/lib/concentrate/group_filter/closed_stop.ex
+++ b/lib/concentrate/group_filter/closed_stop.ex
@@ -10,9 +10,11 @@ defmodule Concentrate.GroupFilter.ClosedStop do
   def filter(update, stops_module \\ ClosedStops)
 
   def filter({%TripDescriptor{} = td, vps, stus}, stops_module) do
+    route_id = TripDescriptor.route_id(td)
+
     match = [
       trip_id: TripDescriptor.trip_id(td),
-      route_id: TripDescriptor.route_id(td),
+      route_id: route_id,
       direction_id: TripDescriptor.direction_id(td)
     ]
 
@@ -21,7 +23,7 @@ defmodule Concentrate.GroupFilter.ClosedStop do
         time = StopTimeUpdate.time(stu)
 
         if is_integer(time) do
-          entities = stops_module.stop_closed_for(StopTimeUpdate.stop_id(stu), time)
+          entities = stops_module.stop_closed_for(StopTimeUpdate.stop_id(stu), route_id, time)
           update_stu_from_closed_entities(stu, match, entities)
         else
           stu

--- a/test/concentrate/filter/alert/closed_stops_test.exs
+++ b/test/concentrate/filter/alert/closed_stops_test.exs
@@ -23,7 +23,8 @@ defmodule Concentrate.Filter.Alert.ClosedStopsTest do
           informed_entity: [
             stop_only = InformedEntity.new(stop_id: "stop"),
             stop_route = InformedEntity.new(stop_id: "other", route_id: "route"),
-            stop_route_2 = InformedEntity.new(stop_id: "other", route_id: "route 2")
+            stop_route_2 = InformedEntity.new(stop_id: "other", route_id: "route 2"),
+            InformedEntity.new(stop_id: "partially_closed", activities: ["RIDE", "EXIT"])
           ]
         )
 
@@ -35,6 +36,7 @@ defmodule Concentrate.Filter.Alert.ClosedStopsTest do
       assert stop_closed_for("other", "route 2", 20) == [stop_route_2]
       assert stop_closed_for("other", "other_route", 20) == []
       assert stop_closed_for("stop", "route", 12) == []
+      assert stop_closed_for("partially_closed", "route", 5) == []
       assert stop_closed_for("unknown", "route", 8) == []
     end
 

--- a/test/concentrate/filter/alert/closed_stops_test.exs
+++ b/test/concentrate/filter/alert/closed_stops_test.exs
@@ -22,14 +22,18 @@ defmodule Concentrate.Filter.Alert.ClosedStopsTest do
           ],
           informed_entity: [
             stop_only = InformedEntity.new(stop_id: "stop"),
-            stop_route = InformedEntity.new(stop_id: "other", route_id: "route")
+            stop_route = InformedEntity.new(stop_id: "other", route_id: "route"),
+            stop_route_2 = InformedEntity.new(stop_id: "other", route_id: "route 2")
           ]
         )
 
       handle_events([[alert]], :from, :state)
 
       assert stop_closed_for("stop", "route", 5) == [stop_only]
+      assert stop_closed_for("stop", "other_route", 5) == [stop_only]
       assert stop_closed_for("other", "route", 20) == [stop_route]
+      assert stop_closed_for("other", "route 2", 20) == [stop_route_2]
+      assert stop_closed_for("other", "other_route", 20) == []
       assert stop_closed_for("stop", "route", 12) == []
       assert stop_closed_for("unknown", "route", 8) == []
     end

--- a/test/concentrate/filter/alert/closed_stops_test.exs
+++ b/test/concentrate/filter/alert/closed_stops_test.exs
@@ -9,7 +9,7 @@ defmodule Concentrate.Filter.Alert.ClosedStopsTest do
     :ok
   end
 
-  describe "stop_closed_for/2" do
+  describe "stop_closed_for/3" do
     setup :supervised
 
     test "returns a list of entities for which the stop is closed at the given time" do
@@ -28,10 +28,10 @@ defmodule Concentrate.Filter.Alert.ClosedStopsTest do
 
       handle_events([[alert]], :from, :state)
 
-      assert stop_closed_for("stop", 5) == [stop_only]
-      assert stop_closed_for("other", 20) == [stop_route]
-      assert stop_closed_for("stop", 12) == []
-      assert stop_closed_for("unknown", 8) == []
+      assert stop_closed_for("stop", "route", 5) == [stop_only]
+      assert stop_closed_for("other", "route", 20) == [stop_route]
+      assert stop_closed_for("stop", "route", 12) == []
+      assert stop_closed_for("unknown", "route", 8) == []
     end
 
     test "for route types 3 and 4, :DETOUR is also a closed stop" do
@@ -52,18 +52,18 @@ defmodule Concentrate.Filter.Alert.ClosedStopsTest do
 
       handle_events([[alert]], :from, :state)
 
-      assert stop_closed_for("bus", 5) == [bus]
-      assert stop_closed_for("ferry", 6) == [ferry]
+      assert stop_closed_for("bus", "bus_route", 5) == [bus]
+      assert stop_closed_for("ferry", "ferry_route", 6) == [ferry]
 
       for name <- ~w(light_rail heavy_rail commuter_rail) do
-        assert stop_closed_for(name, 6) == []
+        assert stop_closed_for(name, "#{name}_route", 6) == []
       end
     end
   end
 
   describe "missing ETS table" do
     test "stop_closed_for/2 returns empty list" do
-      assert stop_closed_for("stop", 0) == []
+      assert stop_closed_for("stop", "route", 0) == []
     end
   end
 end

--- a/test/support/filter/fakes.ex
+++ b/test/support/filter/fakes.ex
@@ -58,7 +58,7 @@ defmodule Concentrate.Filter.FakeClosedStops do
   @moduledoc "Fake implementation of Filter.Alerts.ClosedStops"
   alias Concentrate.Alert.InformedEntity
 
-  def stop_closed_for("stop", unix) do
+  def stop_closed_for("stop", route_id, unix) do
     cond do
       unix < 5 ->
         []
@@ -66,20 +66,23 @@ defmodule Concentrate.Filter.FakeClosedStops do
       unix > 10 ->
         []
 
-      true ->
+      route_id == "route" ->
         [
           InformedEntity.new(trip_id: "trip", route_id: "route")
         ]
+
+      true ->
+        []
     end
   end
 
-  def stop_closed_for("route_stop", _) do
+  def stop_closed_for("route_stop", "other_route", _) do
     [
-      InformedEntity.new(route_id: "other_route")
+      InformedEntity.new(stop_id: "route_stop", route_id: "other_route")
     ]
   end
 
-  def stop_closed_for(_, _) do
+  def stop_closed_for(_, _, _) do
     []
   end
 end


### PR DESCRIPTION
#### Summary of changes

Two updates for how we treat closed stops:

- take the route into account when checking for closed stops
- only treat a NO_SERVICE stop as closed if it's affecting both BOARD and EXIT activities

Seems to be working better on dev-green: 
- https://api-dev-green.mbtace.com/predictions?filter[stop]=70196&filter[route]=Green-B (not skipped)
- https://api-dev-green.mbtace.com/predictions?filter[stop]=70196&filter[route]=Green-D (still skipped)