### PR TITLE
fix: remove terminal predictions for cleveland circle and 

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -69,7 +69,7 @@ config :concentrate,
     },
     {
       Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates,
-      uncertainties_by_route: %{"Green-C" => [120, 360], "Green-D" => [120, 360]}
+      uncertainties_by_route: %{"Green-C" => %{120 => [1], 360 => [1]}, "Green-D" => %{120 => [1], 360 => [1]}}
     },
     Concentrate.GroupFilter.TimeOutOfRange,
     Concentrate.GroupFilter.RemoveUnneededTimes,

--- a/config/config.exs
+++ b/config/config.exs
@@ -67,6 +67,10 @@ config :concentrate,
       # https://github.com/mbta/commuter_rail_boarding/blob/79a493f/config/config.exs#L34-L63
       on_time_statuses: ["All aboard", "Now boarding", "On time", "On Time"]
     },
+    {
+      Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates,
+      uncertainties_by_route: %{"Green-C" => [120, 360], "Green-D" => [120, 360]}
+    },
     Concentrate.GroupFilter.TimeOutOfRange,
     Concentrate.GroupFilter.RemoveUnneededTimes,
     Concentrate.GroupFilter.Shuttle,

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,7 +6,8 @@ config :logger,
   always_evaluate_messages: true
 
 config :concentrate, :group_filters, [
-  {Concentrate.GroupFilter.ScheduledStopTimes, on_time_statuses: ["on time"]}
+  {Concentrate.GroupFilter.ScheduledStopTimes, on_time_statuses: ["on time"]},
+  Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates
 ]
 
 config :concentrate, :sink_s3, ex_aws: Concentrate.TestExAws

--- a/test/concentrate/group_filter/remove_uncertain_stop_time_updates_test.exs
+++ b/test/concentrate/group_filter/remove_uncertain_stop_time_updates_test.exs
@@ -13,7 +13,10 @@ defmodule Concentrate.GroupFilter.RemoveUncertainStopTimesTest do
         {nil, [], [StopTimeUpdate.new(trip_id: "green_c_trip", uncertainty: @reverse_prediction)]}
 
       assert RemoveUncertainStopTimeUpdates.filter(group, %{
-               "Red" => [@at_terminal, @reverse_prediction]
+               "Red" => [
+                 %{@at_terminal => [0, 1]},
+                 %{@reverse_prediction => [0, 1]}
+               ]
              }) == group
     end
 
@@ -31,22 +34,30 @@ defmodule Concentrate.GroupFilter.RemoveUncertainStopTimesTest do
          [StopTimeUpdate.new(trip_id: "red_trip", uncertainty: @mid_trip)]}
 
       assert RemoveUncertainStopTimeUpdates.filter(group, %{
-               "Red" => [@at_terminal, @reverse_prediction]
+               "Red" => %{@at_terminal => [0, 1], @reverse_prediction => [0, 1]}
+             }) == group
+
+      group =
+        {TripDescriptor.new(trip_id: "red_trip", route_id: "Red", direction_id: 0), [],
+         [StopTimeUpdate.new(trip_id: "red_trip", uncertainty: @reverse_prediction)]}
+
+      assert RemoveUncertainStopTimeUpdates.filter(group, %{
+               "Red" => %{@at_terminal => [1], @reverse_prediction => [1]}
              }) == group
     end
 
     test "removes uncertain predictions for specified routes" do
       group =
-        {TripDescriptor.new(trip_id: "red_trip", route_id: "Red"), [],
+        {TripDescriptor.new(trip_id: "red_trip", route_id: "Red", direction_id: 0), [],
          [
            StopTimeUpdate.new(trip_id: "red_trip", uncertainty: @at_terminal),
            StopTimeUpdate.new(trip_id: "red_trip", uncertainty: @reverse_prediction)
          ]}
 
       assert RemoveUncertainStopTimeUpdates.filter(group, %{
-               "Red" => [@at_terminal, @reverse_prediction]
+               "Red" => %{@at_terminal => [0, 1], @reverse_prediction => [0, 1]}
              }) ==
-               {TripDescriptor.new(trip_id: "red_trip", route_id: "Red"), [], []}
+               {TripDescriptor.new(trip_id: "red_trip", route_id: "Red", direction_id: 0), [], []}
     end
   end
 end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** n/a

Filter out errant terminal predictions for Cleveland Circle going Eastbound and Medford Tufts going westbound.
