### PR TITLE
chore: revert filtering of light rail terminal predictions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -67,13 +67,6 @@ config :concentrate,
       # https://github.com/mbta/commuter_rail_boarding/blob/79a493f/config/config.exs#L34-L63
       on_time_statuses: ["All aboard", "Now boarding", "On time", "On Time"]
     },
-    {
-      Concentrate.GroupFilter.RemoveUncertainStopTimeUpdates,
-      uncertainties_by_route: %{
-        "Green-C" => %{120 => [1], 360 => [1]},
-        "Green-E" => %{120 => [0], 360 => [0]}
-      }
-    },
     Concentrate.GroupFilter.TimeOutOfRange,
     Concentrate.GroupFilter.RemoveUnneededTimes,
     Concentrate.GroupFilter.Shuttle,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** none, ad-hoc

This undoes, but is not a straight revert of, the changes in #369 now that we have fixed the underlying RTR issue.