### PR TITLE
fix(cancelled-trips): re-implement making skipped stop time updates for cancelled trips

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,134 @@
+export CONCENTRATE_JSON=`cat <<EOF
+{
+  "alerts": {
+    "url": "https://mbta-realtime-test.s3.amazonaws.com/alerts_enhanced.json"
+  },
+  "gtfs": {
+    "url": "https://mbta-gtfs-s3.s3.amazonaws.com/MBTA_GTFS-dev-green.zip"
+  },
+  "signs_stops_config": {
+    "url": "s3://mbta-signs-dev/stops-config.json"
+  },
+  "log_level": "debug",
+  "sinks": {
+    "filesystem": {
+      "directory": "/tmp"
+    }
+  },
+  "sources": {
+    "gtfs_realtime": {
+      "bus_tripupdates": {
+        "headers": {
+          "Authorization": {
+            "system": "API_KEY"
+          }
+        },
+        "url": "https://api.goswift.ly/real-time/mbta-bus-test/gtfs-rt-trip-updates"
+      },
+      "bus_vehiclepositions": {
+        "drop_fields": {
+          "VehiclePosition": [
+            "speed",
+            "label"
+          ]
+        },
+        "headers": {
+          "Authorization": {
+            "system": "API_KEY"
+          }
+        },
+        "url": "https://api.goswift.ly/real-time/mbta-bus-test/gtfs-rt-vehicle-positions"
+      },
+      "cr_tripupdates": {
+        "headers": {
+          "Authorization": {
+            "system": "API_KEY"
+          }
+        },
+        "url": "https://api.goswift.ly/real-time/mbta-cr-test/gtfs-rt-trip-updates"
+      },
+      "cr_vehiclepositions": {
+        "headers": {
+          "Authorization": {
+            "system": "API_KEY"
+          }
+        },
+        "url": "https://api.goswift.ly/real-time/mbta-cr-test/gtfs-rt-vehicle-positions"
+      },
+      "winthrop_tripupdates": {
+        "drop_fields": {
+          "VehiclePosition": [
+            "speed"
+          ]
+        },
+        "fetch_after": 1700,
+        "headers": {
+          "Authorization": {
+            "system": "API_KEY"
+          }
+        },
+        "url": "https://api.goswift.ly/real-time/mbta-winthrop/gtfs-rt-trip-updates"
+      },
+      "winthrop_vehiclepositions": {
+        "drop_fields": {
+          "VehiclePosition": [
+            "speed"
+          ]
+        },
+        "headers": {
+          "Authorization": {
+            "system": "API_KEY"
+          }
+        },
+        "url": "https://api.goswift.ly/real-time/mbta-winthrop/gtfs-rt-vehicle-positions"
+      },
+      "bye_bye_bye_tripupdates": "https://mbta-gtfs-s3-dev-green.s3.amazonaws.com/bye-bye-bye/TripUpdates.pb",
+      "ferry_tripupdates": {
+        "headers": {
+          "Authorization": {
+            "system": "API_KEY"
+          }
+        },
+        "url": "https://api.goswift.ly/real-time/mbta-ferry/gtfs-rt-trip-updates"
+      },
+      "ferry_vehiclepositions": {
+        "drop_fields": {
+          "VehiclePosition": [
+            "speed",
+            "label"
+          ]
+        },
+        "headers": {
+          "Authorization": {
+            "system": "API_KEY"
+          }
+        },
+        "url": "https://api.goswift.ly/real-time/mbta-ferry/gtfs-rt-vehicle-positions"
+      }
+    },
+    "gtfs_realtime_enhanced": {
+      "busloc_tripupdates": "https://mbta-busloc-s3.s3.amazonaws.com/dev/TripUpdates_enhanced.json",
+      "busloc_vehiclepositions": {
+        "drop_fields": {
+          "VehiclePosition": [
+            "speed"
+          ]
+        },
+        "url": "https://mbta-busloc-s3.s3.amazonaws.com/dev/VehiclePositions_enhanced.json"
+      },
+      "rtr_tripupdates": "https://mbta-gtfs-s3-dev-green.s3.amazonaws.com/rtr/TripUpdates_enhanced.json",
+      "rtr_vehiclepositions": {
+        "fetch_after": 500,
+        "url": "https://mbta-gtfs-s3-dev-green.s3.amazonaws.com/rtr/VehiclePositions_enhanced.json"
+      },
+      "keolis_tripupdates": "https://mbta-gtfs-commuter-rail-staging.s3.amazonaws.com/TripUpdates_enhanced.json",
+      "keolis_vehicle_positions": {
+        "url": "https://mbta-gtfs-commuter-rail-staging.s3.amazonaws.com/VehiclePositions_enhanced.json",
+        "fetch_after": 500
+      }
+    }
+  }
+}
+EOF
+`
+export API_KEY=

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,13 +1,13 @@
 export CONCENTRATE_JSON=`cat <<EOF
 {
   "alerts": {
-    "url": "https://mbta-realtime-test.s3.amazonaws.com/alerts_enhanced.json"
+    "url": "example.com"
   },
   "gtfs": {
-    "url": "https://mbta-gtfs-s3.s3.amazonaws.com/MBTA_GTFS-dev-green.zip"
+    "url": "example.com"
   },
   "signs_stops_config": {
-    "url": "s3://mbta-signs-dev/stops-config.json"
+    "url": "s3://example/stops-config.json"
   },
   "log_level": "debug",
   "sinks": {
@@ -23,7 +23,7 @@ export CONCENTRATE_JSON=`cat <<EOF
             "system": "API_KEY"
           }
         },
-        "url": "https://api.goswift.ly/real-time/mbta-bus-test/gtfs-rt-trip-updates"
+        "url": "example.com"
       },
       "bus_vehiclepositions": {
         "drop_fields": {
@@ -37,7 +37,7 @@ export CONCENTRATE_JSON=`cat <<EOF
             "system": "API_KEY"
           }
         },
-        "url": "https://api.goswift.ly/real-time/mbta-bus-test/gtfs-rt-vehicle-positions"
+        "url": "example.com"
       },
       "cr_tripupdates": {
         "headers": {
@@ -45,7 +45,7 @@ export CONCENTRATE_JSON=`cat <<EOF
             "system": "API_KEY"
           }
         },
-        "url": "https://api.goswift.ly/real-time/mbta-cr-test/gtfs-rt-trip-updates"
+        "url": "example.com"
       },
       "cr_vehiclepositions": {
         "headers": {
@@ -53,7 +53,7 @@ export CONCENTRATE_JSON=`cat <<EOF
             "system": "API_KEY"
           }
         },
-        "url": "https://api.goswift.ly/real-time/mbta-cr-test/gtfs-rt-vehicle-positions"
+        "url": "example.com"
       },
       "winthrop_tripupdates": {
         "drop_fields": {
@@ -67,7 +67,7 @@ export CONCENTRATE_JSON=`cat <<EOF
             "system": "API_KEY"
           }
         },
-        "url": "https://api.goswift.ly/real-time/mbta-winthrop/gtfs-rt-trip-updates"
+        "url": "example.com"
       },
       "winthrop_vehiclepositions": {
         "drop_fields": {
@@ -80,16 +80,16 @@ export CONCENTRATE_JSON=`cat <<EOF
             "system": "API_KEY"
           }
         },
-        "url": "https://api.goswift.ly/real-time/mbta-winthrop/gtfs-rt-vehicle-positions"
+        "url": "example.com"
       },
-      "bye_bye_bye_tripupdates": "https://mbta-gtfs-s3-dev-green.s3.amazonaws.com/bye-bye-bye/TripUpdates.pb",
+      "bye_bye_bye_tripupdates": "example.com"
       "ferry_tripupdates": {
         "headers": {
           "Authorization": {
             "system": "API_KEY"
           }
         },
-        "url": "https://api.goswift.ly/real-time/mbta-ferry/gtfs-rt-trip-updates"
+        "url": "example.com"
       },
       "ferry_vehiclepositions": {
         "drop_fields": {
@@ -103,27 +103,27 @@ export CONCENTRATE_JSON=`cat <<EOF
             "system": "API_KEY"
           }
         },
-        "url": "https://api.goswift.ly/real-time/mbta-ferry/gtfs-rt-vehicle-positions"
+        "url": "example.com"
       }
     },
     "gtfs_realtime_enhanced": {
-      "busloc_tripupdates": "https://mbta-busloc-s3.s3.amazonaws.com/dev/TripUpdates_enhanced.json",
+      "busloc_tripupdates": "example.com"
       "busloc_vehiclepositions": {
         "drop_fields": {
           "VehiclePosition": [
             "speed"
           ]
         },
-        "url": "https://mbta-busloc-s3.s3.amazonaws.com/dev/VehiclePositions_enhanced.json"
+        "url": "example.com"
       },
-      "rtr_tripupdates": "https://mbta-gtfs-s3-dev-green.s3.amazonaws.com/rtr/TripUpdates_enhanced.json",
+      "rtr_tripupdates": "example.com"
       "rtr_vehiclepositions": {
         "fetch_after": 500,
-        "url": "https://mbta-gtfs-s3-dev-green.s3.amazonaws.com/rtr/VehiclePositions_enhanced.json"
+        "url": "example.com"
       },
-      "keolis_tripupdates": "https://mbta-gtfs-commuter-rail-staging.s3.amazonaws.com/TripUpdates_enhanced.json",
+      "keolis_tripupdates": "example.com"
       "keolis_vehicle_positions": {
-        "url": "https://mbta-gtfs-commuter-rail-staging.s3.amazonaws.com/VehiclePositions_enhanced.json",
+        "url": "example.com"
         "fetch_after": 500
       }
     }

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ concentrate-*.tar
 
 # Ignore any local configuration
 /config/*.local.exs
+
+# ignore environment run commands
+.envrc

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ single output files.
 
 Concentrate can either be configured via `config/config.exs` or a JSON environment variable as `CONCENTRATE_JSON`: more details are available in [configuration.md](guides/configuration.md).
 
+An example run commands bash script for configuring Concentrate is available in `.envrc.example`. Note that you must run apply this configuration in a bash shell by using `source` instead of via `direnv` or a
+similar tool, since it runs bash commands.
+
 ## Architecture
 
 See [architecture.md](guides/architecture.md) for the overall architecture of the system.
-
+ fc
 ## Development Setup
 
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ similar tool, since it runs bash commands.
 ## Architecture
 
 See [architecture.md](guides/architecture.md) for the overall architecture of the system.
- fc
 ## Development Setup
 
 ```

--- a/lib/concentrate/group_filter/cancelled_trip.ex
+++ b/lib/concentrate/group_filter/cancelled_trip.ex
@@ -7,6 +7,8 @@ defmodule Concentrate.GroupFilter.CancelledTrip do
   alias Concentrate.GTFS.Routes
   alias Concentrate.{StopTimeUpdate, TripDescriptor}
 
+  require Logger
+
   @impl Concentrate.GroupFilter
   def filter(trip_group, module \\ CancelledTrips, routes_module \\ Routes)
 
@@ -42,7 +44,7 @@ defmodule Concentrate.GroupFilter.CancelledTrip do
 
   def filter(other, _module, _trips_module), do: other
 
-  defp bus_block_waiver?(stop_time_updates, 3) do
+  defp bus_block_waiver?([_ | _] = stop_time_updates, 3) do
     Enum.all?(stop_time_updates, &StopTimeUpdate.skipped?(&1))
   end
 

--- a/lib/concentrate/group_filter/cancelled_trip.ex
+++ b/lib/concentrate/group_filter/cancelled_trip.ex
@@ -4,45 +4,60 @@ defmodule Concentrate.GroupFilter.CancelledTrip do
   """
   @behaviour Concentrate.GroupFilter
   alias Concentrate.Filter.Alert.CancelledTrips
-  alias Concentrate.GTFS.Routes
+  alias Concentrate.GTFS.{Routes, StopTimes}
   alias Concentrate.{StopTimeUpdate, TripDescriptor}
 
   require Logger
 
   @impl Concentrate.GroupFilter
-  def filter(trip_group, module \\ CancelledTrips, routes_module \\ Routes)
+  def filter(
+        trip_group,
+        module \\ CancelledTrips,
+        routes_module \\ Routes,
+        gtfs_stop_times \\ StopTimes
+      )
 
   def filter(
-        {%TripDescriptor{} = td, _vps, [stu | _] = stop_time_updates} = group,
+        {%TripDescriptor{} = td, _vps, stop_time_updates} = group,
         module,
-        routes_module
+        routes_module,
+        gtfs_stop_times
       ) do
     trip_id = TripDescriptor.trip_id(td)
     route_id = TripDescriptor.route_id(td)
-    time = StopTimeUpdate.time(stu)
+
+    time = maybe_time(stop_time_updates)
 
     cond do
       TripDescriptor.schedule_relationship(td) == :CANCELED ->
-        cancel_group(group)
+        cancel_group(group, gtfs_stop_times)
 
       bus_block_waiver?(stop_time_updates, routes_module.route_type(route_id)) ->
-        cancel_group(group)
+        cancel_group(group, gtfs_stop_times)
 
       is_nil(time) ->
         group
 
       is_binary(trip_id) and module.trip_cancelled?(trip_id, time) ->
-        cancel_group(group)
+        cancel_group(group, gtfs_stop_times)
 
       is_binary(route_id) and module.route_cancelled?(route_id, time) ->
-        cancel_group(group)
+        cancel_group(group, gtfs_stop_times)
 
       true ->
         group
     end
   end
 
-  def filter(other, _module, _trips_module), do: other
+  def filter(other, _module, _trips_module, _gtfs_stop_times), do: other
+
+  defp maybe_time([stu | _]) do
+    StopTimeUpdate.time(stu)
+  end
+
+  defp maybe_time(_) do
+    nil
+  end
 
   defp bus_block_waiver?([_ | _] = stop_time_updates, 3) do
     Enum.all?(stop_time_updates, &StopTimeUpdate.skipped?(&1))
@@ -50,7 +65,37 @@ defmodule Concentrate.GroupFilter.CancelledTrip do
 
   defp bus_block_waiver?(_, _), do: false
 
-  defp cancel_group({td, vps, stus}) do
+  defp cancel_group({td, vps, nil}, gtfs_stop_times) do
+    cancel_group({td, vps, []}, gtfs_stop_times)
+  end
+
+  defp cancel_group({td, vps, []}, gtfs_stop_times) do
+    td = TripDescriptor.cancel(td)
+    trip_id = TripDescriptor.trip_id(td)
+
+    stops_for_trip = gtfs_stop_times.stops_for_trip(trip_id)
+
+    stus =
+      case stops_for_trip do
+        [_ | _] ->
+          Enum.map(stops_for_trip, fn
+            {stop_sequence, stop_id} ->
+              StopTimeUpdate.new(
+                trip_id: trip_id,
+                stop_sequence: stop_sequence,
+                stop_id: stop_id,
+                schedule_relationship: :SKIPPED
+              )
+          end)
+
+        :unknown ->
+          []
+      end
+
+    {td, vps, stus}
+  end
+
+  defp cancel_group({td, vps, stus}, _) do
     td = TripDescriptor.cancel(td)
     stus = Enum.map(stus, &StopTimeUpdate.skip/1)
     {td, vps, stus}

--- a/lib/concentrate/gtfs/stop_times.ex
+++ b/lib/concentrate/gtfs/stop_times.ex
@@ -62,6 +62,22 @@ defmodule Concentrate.GTFS.StopTimes do
     end
   end
 
+  @doc "Gets every stop that the GTFS static trip visits, ordered by sequence"
+  @spec stops_for_trip(String.t()) :: list({integer(), String.t()})
+  def stops_for_trip(trip_id) do
+    case select_stops_for_trip(trip_id) do
+      [[stops | _] | _] ->
+        stops
+
+      _ ->
+        :unknown
+    end
+  end
+
+  defp select_stops_for_trip(trip_id) do
+    :ets.match(Concentrate.GTFS.StopTimes, {trip_id, :"$1"})
+  end
+
   @spec lookup(object_key) :: object_value | nil
   defp lookup(key) do
     :ets.lookup_element(@table, key, 2)
@@ -96,6 +112,7 @@ defmodule Concentrate.GTFS.StopTimes do
        }) do
     trip_time_zones = trip_time_zones(agencies, routes, trips)
     inserts = stop_times_inserts(stop_times, trip_time_zones)
+
     true = :ets.delete_all_objects(@table)
     :ets.insert(@table, inserts)
 
@@ -125,13 +142,43 @@ defmodule Concentrate.GTFS.StopTimes do
   end
 
   defp stop_times_inserts(stop_times, trip_time_zones) do
-    stop_times
-    |> Helpers.io_stream()
-    |> CSV.decode(headers: true, num_workers: System.schedulers())
-    |> Enum.flat_map(fn
-      {:ok, %{"trip_id" => trip_id} = row} -> build_inserts(row, trip_time_zones[trip_id])
-      {:error, _} -> []
-    end)
+    inserts_by_trip_id_stop_sequence =
+      stop_times
+      |> Helpers.io_stream()
+      |> CSV.decode(headers: true, num_workers: System.schedulers())
+      |> Enum.flat_map(fn
+        {:ok, %{"trip_id" => trip_id} = row} -> build_inserts(row, trip_time_zones[trip_id])
+        {:error, _} -> []
+      end)
+
+    inserts_by_trip_id =
+      Enum.reduce(inserts_by_trip_id_stop_sequence, %{}, fn {
+                                                              {trip_id, stop_sequence},
+                                                              {stop_id, _arrival, _departure,
+                                                               _time_zone, _pick_up?, _drop_off?}
+                                                            },
+                                                            acc ->
+        Map.update(
+          acc,
+          trip_id,
+          [{stop_sequence, stop_id}],
+          fn trip_stop_times ->
+            [
+              {stop_sequence, stop_id}
+              | trip_stop_times
+            ]
+          end
+        )
+      end)
+      |> Map.to_list()
+      |> Enum.map(fn {trip_id, stop_times} ->
+        sorted_stop_times =
+          Enum.sort_by(stop_times, fn {stop_sequence, _stop_id} -> stop_sequence end)
+
+        {trip_id, sorted_stop_times}
+      end)
+
+    inserts_by_trip_id_stop_sequence ++ inserts_by_trip_id
   end
 
   defp build_inserts(row, time_zone) when is_binary(time_zone) do
@@ -144,7 +191,9 @@ defmodule Concentrate.GTFS.StopTimes do
     pick_up? = type_to_boolean(row["pickup_type"])
     drop_off? = type_to_boolean(row["drop_off_type"])
 
-    [{{trip_id, stop_sequence}, {stop_id, arrival, departure, time_zone, pick_up?, drop_off?}}]
+    [
+      {{trip_id, stop_sequence}, {stop_id, arrival, departure, time_zone, pick_up?, drop_off?}}
+    ]
   end
 
   defp build_inserts(_, _), do: []

--- a/test/concentrate/group_filter/cancelled_trip_test.exs
+++ b/test/concentrate/group_filter/cancelled_trip_test.exs
@@ -89,6 +89,72 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
       assert StopTimeUpdate.schedule_relationship(stu_actual2) == :SKIPPED
     end
 
+    test "does not cancel the group if there are no stop time updates" do
+      td =
+        TripDescriptor.new(
+          route_id: "1",
+          trip_id: "trip",
+          start_date: {1970, 1, 2}
+        )
+
+      group = {td, [], []}
+
+      {td_actual, [], []} =
+        filter(group, @module, @fake_routes_module, @fake_stop_times_module)
+
+      assert TripDescriptor.schedule_relationship(td_actual) == :SCHEDULED
+    end
+
+    test "creates SKIPPED STUs if there are no STUs for a CANCELED trip" do
+      td =
+        TripDescriptor.new(
+          route_id: "1",
+          trip_id: "trip",
+          start_date: {1970, 1, 2},
+          schedule_relationship: :CANCELED
+        )
+
+      group = {td, [], []}
+
+      {td_actual, [], stus} =
+        filter(group, @module, @fake_routes_module, @fake_stop_times_module)
+
+      assert TripDescriptor.schedule_relationship(td_actual) == :CANCELED
+
+      fake_stops = @fake_stop_times_module.stops_for_trip("trip")
+
+      Enum.each(
+        fake_stops,
+        fn {expected_sequence, expected_stop} ->
+          assert Enum.any?(stus, fn %StopTimeUpdate{
+                                      stop_sequence: sequence,
+                                      stop_id: stop_id,
+                                      schedule_relationship: schedule_relationship
+                                    } ->
+                   sequence == expected_sequence && stop_id == expected_stop &&
+                     schedule_relationship == :SKIPPED
+                 end)
+        end
+      )
+    end
+
+    test "does not create SKIPPED STUs for a cancelled trip for which we don't have stop times" do
+      td =
+        TripDescriptor.new(
+          route_id: "1",
+          trip_id: "unknown",
+          start_date: {1970, 1, 2},
+          schedule_relationship: :CANCELED
+        )
+
+      group = {td, [], []}
+
+      assert {td_actual, [], []} =
+               filter(group, @module, @fake_routes_module, @fake_stop_times_module)
+
+      assert TripDescriptor.schedule_relationship(td_actual) == :CANCELED
+    end
+
     test "does not cancel the group if all stop updates have already been given a skipped status but route_type is not 3" do
       td =
         TripDescriptor.new(

--- a/test/concentrate/group_filter/cancelled_trip_test.exs
+++ b/test/concentrate/group_filter/cancelled_trip_test.exs
@@ -6,6 +6,7 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
 
   @module Concentrate.Filter.FakeCancelledTrips
   @fake_routes_module Concentrate.GTFS.FakeRoutes
+  @fake_stop_times_module Concentrate.GTFS.FakeStopTimes
 
   describe "filter/2" do
     test "cancels the group if the trip is cancelled by an alert" do
@@ -22,7 +23,10 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
         )
 
       group = {td, [], [stu]}
-      {new_td, [], [new_stu]} = filter(group, @module, @fake_routes_module)
+
+      {new_td, [], [new_stu]} =
+        filter(group, @module, @fake_routes_module, @fake_stop_times_module)
+
       assert TripDescriptor.schedule_relationship(new_td) == :CANCELED
       assert StopTimeUpdate.schedule_relationship(new_stu) == :SKIPPED
     end
@@ -42,7 +46,10 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
         )
 
       group = {td, [], [stu]}
-      {new_td, [], [new_stu]} = filter(group, @module, @fake_routes_module)
+
+      {new_td, [], [new_stu]} =
+        filter(group, @module, @fake_routes_module, @fake_stop_times_module)
+
       assert TripDescriptor.schedule_relationship(new_td) == :CANCELED
       assert StopTimeUpdate.schedule_relationship(new_stu) == :SKIPPED
     end
@@ -62,7 +69,7 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
         )
 
       group = {td, [], [stu]}
-      {_td, [], [stu]} = filter(group, @module, @fake_routes_module)
+      {_td, [], [stu]} = filter(group, @module, @fake_routes_module, @fake_stop_times_module)
       assert StopTimeUpdate.schedule_relationship(stu) == :SKIPPED
     end
 
@@ -83,12 +90,16 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
         )
 
       group = {td, [], [stu, stu]}
-      {td_actual, [], [stu_actual1, stu_actual2]} = filter(group, @module, @fake_routes_module)
+
+      {td_actual, [], [stu_actual1, stu_actual2]} =
+        filter(group, @module, @fake_routes_module, @fake_stop_times_module)
+
       assert TripDescriptor.schedule_relationship(td_actual) == :CANCELED
       assert StopTimeUpdate.schedule_relationship(stu_actual1) == :SKIPPED
       assert StopTimeUpdate.schedule_relationship(stu_actual2) == :SKIPPED
     end
 
+<<<<<<< HEAD
     test "does not cancel the group if there are no stop time updates" do
       td =
         TripDescriptor.new(
@@ -105,6 +116,8 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
       assert TripDescriptor.schedule_relationship(td_actual) == :SCHEDULED
     end
 
+=======
+>>>>>>> parent of 62148fb (Revert cancellations (#372))
     test "creates SKIPPED STUs if there are no STUs for a CANCELED trip" do
       td =
         TripDescriptor.new(
@@ -172,7 +185,10 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
         )
 
       group = {td, [], [stu, stu]}
-      {td_actual, [], [stu_actual1, stu_actual2]} = filter(group, @module, @fake_routes_module)
+
+      {td_actual, [], [stu_actual1, stu_actual2]} =
+        filter(group, @module, @fake_routes_module, @fake_stop_times_module)
+
       assert TripDescriptor.schedule_relationship(td_actual) == :SCHEDULED
       assert StopTimeUpdate.schedule_relationship(stu_actual1) == :SKIPPED
       assert StopTimeUpdate.schedule_relationship(stu_actual2) == :SKIPPED
@@ -201,7 +217,10 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
         )
 
       group = {td, [], [stu1, stu2]}
-      {td_actual, [], [stu_actual1, stu_actual2]} = filter(group, @module, @fake_routes_module)
+
+      {td_actual, [], [stu_actual1, stu_actual2]} =
+        filter(group, @module, @fake_routes_module, @fake_stop_times_module)
+
       assert TripDescriptor.schedule_relationship(td_actual) == :SCHEDULED
       assert StopTimeUpdate.schedule_relationship(stu_actual1) == :SKIPPED
       assert StopTimeUpdate.schedule_relationship(stu_actual2) == :SCHEDULED
@@ -221,7 +240,7 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
         )
 
       group = {td, [], [stu]}
-      assert filter(group, @module, @fake_routes_module) == group
+      assert filter(group, @module, @fake_routes_module, @fake_stop_times_module) == group
     end
 
     test "does not cancel the group if the route was cancelled at a different time" do
@@ -239,7 +258,7 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
         )
 
       group = {td, [], [stu]}
-      assert filter(group, @module, @fake_routes_module) == group
+      assert filter(group, @module, @fake_routes_module, @fake_stop_times_module) == group
     end
 
     test "other values are returned as-is" do

--- a/test/concentrate/group_filter/cancelled_trip_test.exs
+++ b/test/concentrate/group_filter/cancelled_trip_test.exs
@@ -99,7 +99,6 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
       assert StopTimeUpdate.schedule_relationship(stu_actual2) == :SKIPPED
     end
 
-<<<<<<< HEAD
     test "does not cancel the group if there are no stop time updates" do
       td =
         TripDescriptor.new(
@@ -116,8 +115,6 @@ defmodule Concentrate.GroupFilter.CancelledTripTest do
       assert TripDescriptor.schedule_relationship(td_actual) == :SCHEDULED
     end
 
-=======
->>>>>>> parent of 62148fb (Revert cancellations (#372))
     test "creates SKIPPED STUs if there are no STUs for a CANCELED trip" do
       td =
         TripDescriptor.new(

--- a/test/concentrate/gtfs/stop_times_test.exs
+++ b/test/concentrate/gtfs/stop_times_test.exs
@@ -102,4 +102,20 @@ defmodule Concentrate.GTFS.StopTimesTest do
       assert StopTimes.stop_id("CR-524518-2019", 10) == :unknown
     end
   end
+
+  describe "stops_for_trip/1" do
+    setup :supervised
+
+    test "returns stops and sequence numbers for trip in sequence order" do
+      assert StopTimes.stops_for_trip("CR-524522-2502") == [
+               {0, "WML-0442-CS"},
+               {10, "WML-0364"},
+               {20, "WML-0340"}
+             ]
+    end
+
+    test "returns unknown for unknown trip" do
+      assert StopTimes.stops_for_trip("foo") == :unknown
+    end
+  end
 end

--- a/test/support/filter/fakes.ex
+++ b/test/support/filter/fakes.ex
@@ -19,6 +19,20 @@ defmodule Concentrate.GTFS.FakeRoutes do
   def route_type(_), do: nil
 end
 
+defmodule Concentrate.GTFS.FakeStopTimes do
+  @moduledoc "Fake implementation of GTFS.StopTimes"
+  def stops_for_trip("unknown"), do: :unknown
+
+  def stops_for_trip(trip_id) when is_binary(trip_id) do
+    [
+      {1, "1"},
+      {2, "2"},
+      {3, "3"},
+      {4, "4"}
+    ]
+  end
+end
+
 defmodule Concentrate.Filter.FakeCancelledTrips do
   @moduledoc "Fake implementation of Filter.Alerts.CancelledTrips"
   def route_cancelled?("route", {1970, 1, 2}) do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🧠 Re-implement SKIPPED StopTimeUpdates for CANCELLED trips](https://app.asana.com/1/15492006741476/project/584764604969369/task/1210575419129897?focus=true)

Problem:
The PR that we previously deployed to add SKIPPED StopTimeUpdates for CANCELLED trips resulted in stop information "flickering" for the buses such that the stop to which a bus was headed would appear and disappear intermittently.

Solution:
This was happening because the `bus_block_waiver?/2` function returned `true` for trips with no `StopTimeUpdates`, and RTR intermittently gets bus trips with no `StopTimeUpdates` (likely from Busloc?). Previously, these trips were most likely ignored, but now they cause us to cancel bus trips unnecessarily, which causes us to [remove](https://github.com/mbta/concentrate/blob/647866e0734fd5ae36dda440631e57a69561c375/lib/concentrate/group_filter/vehicle_at_skipped_stop.ex#L1) the `stop_id` for the `VehiclePosition` entities. This PR makes it so that we only consider bus trips with all `SKIPPED` `StopTimeUpdates` as block waivers.