### PR TITLE
Include arrival and departure with passthrough

### DIFF
--- a/lib/concentrate/encoder/trip_updates_enhanced.ex
+++ b/lib/concentrate/encoder/trip_updates_enhanced.ex
@@ -38,13 +38,9 @@ defmodule Concentrate.Encoder.TripUpdatesEnhanced do
     })
   end
 
-  defp determine_arrival_value(%{passthrough_time: nil} = update),
+  defp determine_arrival_value(update),
     do: stop_time_event(StopTimeUpdate.arrival_time(update), StopTimeUpdate.uncertainty(update))
 
-  defp determine_arrival_value(_), do: nil
-
-  defp determine_departure_value(%{passthrough_time: nil} = update),
+  defp determine_departure_value(update),
     do: stop_time_event(StopTimeUpdate.departure_time(update), StopTimeUpdate.uncertainty(update))
-
-  defp determine_departure_value(_), do: nil
 end

--- a/lib/concentrate/encoder/trip_updates_enhanced.ex
+++ b/lib/concentrate/encoder/trip_updates_enhanced.ex
@@ -29,18 +29,14 @@ defmodule Concentrate.Encoder.TripUpdatesEnhanced do
     drop_nil_values(%{
       stop_id: StopTimeUpdate.stop_id(update),
       stop_sequence: StopTimeUpdate.stop_sequence(update),
-      arrival: determine_arrival_value(update),
-      departure: determine_departure_value(update),
+      arrival:
+        stop_time_event(StopTimeUpdate.arrival_time(update), StopTimeUpdate.uncertainty(update)),
+      departure:
+        stop_time_event(StopTimeUpdate.departure_time(update), StopTimeUpdate.uncertainty(update)),
       passthrough_time: StopTimeUpdate.passthrough_time(update),
       schedule_relationship: schedule_relationship(StopTimeUpdate.schedule_relationship(update)),
       boarding_status: StopTimeUpdate.status(update),
       platform_id: StopTimeUpdate.platform_id(update)
     })
   end
-
-  defp determine_arrival_value(update),
-    do: stop_time_event(StopTimeUpdate.arrival_time(update), StopTimeUpdate.uncertainty(update))
-
-  defp determine_departure_value(update),
-    do: stop_time_event(StopTimeUpdate.departure_time(update), StopTimeUpdate.uncertainty(update))
 end

--- a/test/concentrate/encoder/trip_updates_enhanced_test.exs
+++ b/test/concentrate/encoder/trip_updates_enhanced_test.exs
@@ -273,10 +273,12 @@ defmodule Concentrate.Encoder.TripUpdatesEnhancedTest do
                          "stop_id" => "stop_3"
                        } = stu_3,
                        %{
+                         "arrival" => %{"time" => 200},
+                         "departure" => %{"time" => 250},
                          "passthrough_time" => 200,
                          "schedule_relationship" => "SKIPPED",
                          "stop_id" => "stop_2"
-                       } = stu_2,
+                       } = _stu_2,
                        %{
                          "passthrough_time" => 100,
                          "schedule_relationship" => "SKIPPED",
@@ -289,9 +291,6 @@ defmodule Concentrate.Encoder.TripUpdatesEnhancedTest do
              } = encoded
 
       refute Map.get(stu_1, "arrival")
-      refute Map.get(stu_1, "departure")
-      refute Map.get(stu_2, "arrival")
-      refute Map.get(stu_2, "departure")
       refute Map.get(stu_3, "passthrough_time")
     end
   end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] 🧠 Publish arrival and departure times within non-revenue StopTimeUpdates through Concentrate](https://app.asana.com/1/15492006741476/project/584764604969369/task/1210880282700169?focus=true)

Currently running on dev-blue. I've confirmed that STUs with `passthrough_time` are no longer having their arrival / departure times filtered out in the enhanced feed.
