### PR TITLE
fix: error when json list is passed to decode_entities

### DIFF
--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -91,6 +91,7 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
 
   defp decode_entities(json, _) do
     Logger.error("event=malformed_feed feed=#{inspect(json)}")
+    []
   end
 
   @spec decode_feed_entity(map(), Helpers.Options.t(), integer | nil) :: [any()]

--- a/lib/concentrate/parser/gtfs_realtime_enhanced.ex
+++ b/lib/concentrate/parser/gtfs_realtime_enhanced.ex
@@ -89,6 +89,10 @@ defmodule Concentrate.Parser.GTFSRealtimeEnhanced do
     end
   end
 
+  defp decode_entities(json, _) do
+    Logger.error("event=malformed_feed feed=#{inspect(json)}")
+  end
+
   @spec decode_feed_entity(map(), Helpers.Options.t(), integer | nil) :: [any()]
   defp decode_feed_entity(%{"trip_update" => %{} = trip_update}, options, _feed_timestamp) do
     decode_trip_update(trip_update, options)


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** ad-hoc

Problem:
In the staging environment, Keolis is sending us a JSON list instead of an object in their `TripUpdates_enhanced.json`.

e.g.

```json
[
  {
    "trip_update": {
     ...
    },
    "id": "BasewUpdatedWalpoleTurns-772899-1621"
  },
  ....
]
```

instead of prod where we get

```json
{
  "entity": [
    {
      "trip_update": {
        ...
    },
...
  "header": {
   ...
}
```


This causes a crash that was [spamming sentry:](https://mbtace.sentry.io/issues/7483188181/?alert_rule_id=16989613&alert_type=issue&notification_uuid=a300b42f-6f0e-48d0-9594-7cb8786829a5&project=4504753678712832&referrer=slack)

```
Elixir.Concentrate.Producer.HTTPoison.StateMachine: parse error url="https://mbta-gtfs-commuter-rail-staging.s3.amazonaws.com/TripUpdates_enhanced.json" error=%FunctionClauseError{module: Concentrate.Parser.GTFSRealtimeEnhanced, function: :decode_entities, arity: 2, kind: nil, args: nil, clauses: nil}
    (concentrate 0.1.0) lib/concentrate/parser/gtfs_realtime_enhanced.ex:71:
```


Solution:

Log an error when we are passed a list as the base object in `TripUpdates_enhanced.json` instead of crashing, similar to what we do on  `gtfs_realtime_enhanced.ex:122` for [malformed entities.](https://github.com/mbta/concentrate/blob/2f10d0d74f9d82b8d298275a908978cee5198d82/lib/concentrate/parser/gtfs_realtime_enhanced.ex#L122-L125)
