### PR TITLE
chore(src): Add Lamp as codeowner of Protobuf schema

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @mbta/transit-data
+src/gtfs-realtime.proto @mbta/tid-lamp @mbta/transit-data


### PR DESCRIPTION
## Summary of changes

**Asana Ticket:** [🐞 ingest headsign properly](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1215143305292180?focus=true)

Adds Lamp as an additional codeowner to changes in GTFS-RT schemas so that we have a forcing function to make schema changes on our end.
