### PR TITLE
feat(GroupFilter): Propogate CR Delays to downstream stops

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -76,7 +76,9 @@ config :concentrate,
     Concentrate.GroupFilter.SkippedStopOnAddedTrip,
     Concentrate.GroupFilter.TripDescriptorTimestamp,
     Concentrate.GroupFilter.UncertaintyValue,
-    {Concentrate.GroupFilter.SuppressStopTimeUpdate, terminal_suppression_by_time: %{}}
+    {Concentrate.GroupFilter.SuppressStopTimeUpdate, terminal_suppression_by_time: %{}},
+    {Concentrate.GroupFilter.PropogateDelayedStatus,
+     first_stop_delaying_statuses: ["Delayed"], downstream_status: "Delayed"}
   ],
   source_reporters: [
     Concentrate.SourceReporter.Basic,

--- a/config/config.exs
+++ b/config/config.exs
@@ -77,7 +77,7 @@ config :concentrate,
     Concentrate.GroupFilter.TripDescriptorTimestamp,
     Concentrate.GroupFilter.UncertaintyValue,
     {Concentrate.GroupFilter.SuppressStopTimeUpdate, terminal_suppression_by_time: %{}},
-    {Concentrate.GroupFilter.PropogateDelayedStatus,
+    {Concentrate.GroupFilter.PropogateDownstreamDelays,
      first_stop_delaying_statuses: ["Delayed"], downstream_status: "Delayed"}
   ],
   source_reporters: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -78,7 +78,7 @@ config :concentrate,
     Concentrate.GroupFilter.UncertaintyValue,
     {Concentrate.GroupFilter.SuppressStopTimeUpdate, terminal_suppression_by_time: %{}},
     {Concentrate.GroupFilter.PropogateDownstreamDelays,
-     first_stop_delaying_statuses: ["Delayed"], downstream_status: "Delayed"}
+     matching_statuses: ["Delayed"], downstream_status: "Delayed"}
   ],
   source_reporters: [
     Concentrate.SourceReporter.Basic,

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,7 +21,7 @@ config :concentrate, :group_filters, [
      }
    }},
   {Concentrate.GroupFilter.PropogateDownstreamDelays,
-   first_stop_delaying_statuses: ["Delayed"], downstream_status: "Delayed"}
+   matching_statuses: ["Delayed"], downstream_status: "Delayed"}
 ]
 
 config :concentrate, :sink_s3, ex_aws: Concentrate.TestExAws

--- a/config/test.exs
+++ b/config/test.exs
@@ -19,7 +19,9 @@ config :concentrate, :group_filters, [
        6 => {~T[04:00:00], ~T[07:30:00]},
        7 => {~T[04:00:00], ~T[07:30:00]}
      }
-   }}
+   }},
+  {Concentrate.GroupFilter.PropogateDownstreamDelays,
+   first_stop_delaying_statuses: ["Delayed"], downstream_status: "Delayed"}
 ]
 
 config :concentrate, :sink_s3, ex_aws: Concentrate.TestExAws

--- a/lib/concentrate/group_filter/propogate_delay_status.ex
+++ b/lib/concentrate/group_filter/propogate_delay_status.ex
@@ -1,0 +1,93 @@
+defmodule Concentrate.GroupFilter.PropogateDelayedStatus do
+  @moduledoc """
+  If the first stop of a CR trip has a delaying status, generate StopTimeUpdates
+  for any following stop on the trip has an arrival time in the past and doesn't
+  already have a StopTimeUpdate.
+  """
+  alias Concentrate.Encoder.TripGroup
+  alias Concentrate.GTFS.{Routes, StopTimes}
+  alias Concentrate.{StopTimeUpdate, TripDescriptor}
+  @behaviour Concentrate.GroupFilter
+
+  # TODO: make this environment config and use actual status values
+  @first_stop_delaying_statuses ["Delayed"]
+  @delayed_status "Delayed"
+
+  @impl Concentrate.GroupFilter
+  def filter(
+        %TripGroup{td: %TripDescriptor{} = td, stus: stus} = group,
+        stop_times \\ StopTimes,
+        routes_module \\ Routes,
+        now_fn \\ &now/0
+      ) do
+    route_id = TripDescriptor.route_id(td)
+
+    if !(routes_module.route_type(route_id) == 2 &&
+           TripDescriptor.schedule_relationship(td) == :SCHEDULED) do
+      group
+    else
+      trip_id = TripDescriptor.trip_id(td)
+      trip_date = TripDescriptor.start_date(td)
+
+      stus = propogate_delayed_status(trip_id, trip_date, stus, stop_times, now_fn.())
+      %{group | stus: stus}
+    end
+  end
+
+  defp now do
+    System.system_time(:second)
+  end
+
+  defp propogate_delayed_status(trip_id, trip_date, stus, stop_times, now) do
+    [first_stu | _rest_stus] = stus
+
+    scheduled_stop_times = stop_times.stops_for_trip_with_arrival_departure(trip_id, trip_date)
+
+    if first_stop_delayed?(first_stu, scheduled_stop_times) do
+      add_missing_delayed_stus(
+        TripDescriptor.trip_id(first_stu.td),
+        stus,
+        scheduled_stop_times,
+        now
+      )
+    else
+      stus
+    end
+  end
+
+  defp add_missing_delayed_stus(trip_id, stus, scheduled_stop_times, now) do
+    stop_sequence_to_stu = Map.new(stus, &{&1.stop_sequence, &1})
+
+    Enum.flat_map(scheduled_stop_times, fn scheduled_stop_time ->
+      {stop_sequence, stop_id, arrival, _departure} = scheduled_stop_time
+      existing_stu = Map.get(stop_sequence_to_stu, stop_sequence)
+
+      cond do
+        existing_stu != nil ->
+          [existing_stu]
+
+        !is_nil(arrival) && now > arrival ->
+          [
+            StopTimeUpdate.new(
+              trip_id: trip_id,
+              stop_sequence: stop_sequence,
+              stop_id: stop_id,
+              status: @delayed_status
+            )
+          ]
+
+        true ->
+          []
+      end
+    end)
+  end
+
+  defp first_stop_delayed?(first_stu, [first_scheduled_stop | _rest]) do
+    {stop_sequence, _stop_id, _arrival, _departure} = first_scheduled_stop
+
+    first_stu.stop_sequence == stop_sequence &&
+      first_stu.status in @first_stop_delaying_statuses
+  end
+
+  defp first_stop_delayed?(_first_stu, _scheduled_stop_times), do: false
+end

--- a/lib/concentrate/group_filter/propogate_downstream_delays.ex
+++ b/lib/concentrate/group_filter/propogate_downstream_delays.ex
@@ -7,6 +7,7 @@ defmodule Concentrate.GroupFilter.PropogateDownstreamDelays do
   alias Concentrate.Encoder.TripGroup
   alias Concentrate.GTFS.{Routes, StopTimes}
   alias Concentrate.{StopTimeUpdate, TripDescriptor}
+
   @behaviour Concentrate.GroupFilter
 
   @first_stop_delaying_statuses Enum.map(
@@ -32,8 +33,8 @@ defmodule Concentrate.GroupFilter.PropogateDownstreamDelays do
       ) do
     route_id = TripDescriptor.route_id(td)
 
-    if !(routes_module.route_type(route_id) == 2 &&
-           TripDescriptor.schedule_relationship(td) == :SCHEDULED) do
+    if routes_module.route_type(route_id) != 2 ||
+         TripDescriptor.schedule_relationship(td) != :SCHEDULED do
       group
     else
       trip_id = TripDescriptor.trip_id(td)
@@ -49,14 +50,15 @@ defmodule Concentrate.GroupFilter.PropogateDownstreamDelays do
   end
 
   defp propogate_delayed_status(trip_id, trip_date, stus, stop_time_module, now) do
-    [first_stu | _rest_stus] = stus
-
     scheduled_stop_times =
       stop_time_module.stops_for_trip_with_arrival_departure(trip_id, trip_date)
 
-    if first_stop_delayed?(first_stu, scheduled_stop_times) do
+    first_status_only_stu = first_status_only_stu(stus)
+
+    if first_status_only_stu != nil do
       add_missing_delayed_stus(
         trip_id,
+        first_status_only_stu.stop_sequence,
         stus,
         scheduled_stop_times,
         now
@@ -66,18 +68,18 @@ defmodule Concentrate.GroupFilter.PropogateDownstreamDelays do
     end
   end
 
-  defp add_missing_delayed_stus(trip_id, stus, scheduled_stop_times, now) do
+  defp add_missing_delayed_stus(trip_id, first_stop_sequence, stus, scheduled_stop_times, now) do
     stop_sequence_to_stu = Map.new(stus, &{&1.stop_sequence, &1})
 
     Enum.flat_map(scheduled_stop_times, fn scheduled_stop_time ->
-      {stop_sequence, stop_id, arrival, _departure} = scheduled_stop_time
+      {stop_sequence, stop_id, _arrival, departure} = scheduled_stop_time
       existing_stu = Map.get(stop_sequence_to_stu, stop_sequence)
 
       cond do
         existing_stu != nil ->
           [existing_stu]
 
-        !is_nil(arrival) && now > arrival ->
+        !is_nil(departure) && now > departure && stop_sequence > first_stop_sequence ->
           [
             StopTimeUpdate.new(
               trip_id: trip_id,
@@ -93,16 +95,12 @@ defmodule Concentrate.GroupFilter.PropogateDownstreamDelays do
     end)
   end
 
-  @spec first_stop_delayed?(
-          StopTimeUpdate.t(),
-          list({integer(), String.t(), integer(), integer()})
-        ) :: boolean()
-  defp first_stop_delayed?(first_stu, [
-         {stop_sequence, _stop_id, _arrival, _departure} = _first_stop_time | _rest
-       ]) do
-    first_stu.stop_sequence == stop_sequence &&
-      String.downcase(first_stu.status) in @first_stop_delaying_statuses
+  @spec first_status_only_stu([StopTimeUpdate.t()]) :: StopTimeUpdate.t() | nil
+  defp first_status_only_stu(stus) do
+    Enum.find(stus, fn stu ->
+      String.downcase(stu.status) in @first_stop_delaying_statuses &&
+        stu.arrival_time == nil &&
+        stu.departure_time == nil
+    end)
   end
-
-  defp first_stop_delayed?(_first_stu, _scheduled_stop_times), do: false
 end

--- a/lib/concentrate/group_filter/propogate_downstream_delays.ex
+++ b/lib/concentrate/group_filter/propogate_downstream_delays.ex
@@ -56,7 +56,7 @@ defmodule Concentrate.GroupFilter.PropogateDownstreamDelays do
 
     if first_stop_delayed?(first_stu, scheduled_stop_times) do
       add_missing_delayed_stus(
-        TripDescriptor.trip_id(first_stu.td),
+        trip_id,
         stus,
         scheduled_stop_times,
         now

--- a/lib/concentrate/group_filter/propogate_downstream_delays.ex
+++ b/lib/concentrate/group_filter/propogate_downstream_delays.ex
@@ -1,4 +1,4 @@
-defmodule Concentrate.GroupFilter.PropogateDelayedStatus do
+defmodule Concentrate.GroupFilter.PropogateDownstreamDelays do
   @moduledoc """
   If the first stop of a CR trip has a delaying status, generate StopTimeUpdates
   for any following stop on the trip has an arrival time in the past and doesn't
@@ -9,14 +9,24 @@ defmodule Concentrate.GroupFilter.PropogateDelayedStatus do
   alias Concentrate.{StopTimeUpdate, TripDescriptor}
   @behaviour Concentrate.GroupFilter
 
-  # TODO: make this environment config and use actual status values
-  @first_stop_delaying_statuses ["Delayed"]
-  @delayed_status "Delayed"
+  @first_stop_delaying_statuses Enum.map(
+                                  Application.compile_env(
+                                    :concentrate,
+                                    [:group_filters, __MODULE__, :first_stop_delaying_statuses],
+                                    []
+                                  ),
+                                  &String.downcase/1
+                                )
+  @downstream_status Application.compile_env(
+                       :concentrate,
+                       [:group_filters, __MODULE__, :downstream_status],
+                       "Delayed"
+                     )
 
   @impl Concentrate.GroupFilter
   def filter(
         %TripGroup{td: %TripDescriptor{} = td, stus: stus} = group,
-        stop_times \\ StopTimes,
+        stop_time_module \\ StopTimes,
         routes_module \\ Routes,
         now_fn \\ &now/0
       ) do
@@ -29,7 +39,7 @@ defmodule Concentrate.GroupFilter.PropogateDelayedStatus do
       trip_id = TripDescriptor.trip_id(td)
       trip_date = TripDescriptor.start_date(td)
 
-      stus = propogate_delayed_status(trip_id, trip_date, stus, stop_times, now_fn.())
+      stus = propogate_delayed_status(trip_id, trip_date, stus, stop_time_module, now_fn.())
       %{group | stus: stus}
     end
   end
@@ -38,10 +48,11 @@ defmodule Concentrate.GroupFilter.PropogateDelayedStatus do
     System.system_time(:second)
   end
 
-  defp propogate_delayed_status(trip_id, trip_date, stus, stop_times, now) do
+  defp propogate_delayed_status(trip_id, trip_date, stus, stop_time_module, now) do
     [first_stu | _rest_stus] = stus
 
-    scheduled_stop_times = stop_times.stops_for_trip_with_arrival_departure(trip_id, trip_date)
+    scheduled_stop_times =
+      stop_time_module.stops_for_trip_with_arrival_departure(trip_id, trip_date)
 
     if first_stop_delayed?(first_stu, scheduled_stop_times) do
       add_missing_delayed_stus(
@@ -72,7 +83,7 @@ defmodule Concentrate.GroupFilter.PropogateDelayedStatus do
               trip_id: trip_id,
               stop_sequence: stop_sequence,
               stop_id: stop_id,
-              status: @delayed_status
+              status: @downstream_status
             )
           ]
 
@@ -82,11 +93,15 @@ defmodule Concentrate.GroupFilter.PropogateDelayedStatus do
     end)
   end
 
-  defp first_stop_delayed?(first_stu, [first_scheduled_stop | _rest]) do
-    {stop_sequence, _stop_id, _arrival, _departure} = first_scheduled_stop
-
+  @spec first_stop_delayed?(
+          StopTimeUpdate.t(),
+          list({integer(), String.t(), integer(), integer()})
+        ) :: boolean()
+  defp first_stop_delayed?(first_stu, [
+         {stop_sequence, _stop_id, _arrival, _departure} = _first_stop_time | _rest
+       ]) do
     first_stu.stop_sequence == stop_sequence &&
-      first_stu.status in @first_stop_delaying_statuses
+      String.downcase(first_stu.status) in @first_stop_delaying_statuses
   end
 
   defp first_stop_delayed?(_first_stu, _scheduled_stop_times), do: false

--- a/lib/concentrate/group_filter/propogate_downstream_delays.ex
+++ b/lib/concentrate/group_filter/propogate_downstream_delays.ex
@@ -10,14 +10,14 @@ defmodule Concentrate.GroupFilter.PropogateDownstreamDelays do
 
   @behaviour Concentrate.GroupFilter
 
-  @first_stop_delaying_statuses Enum.map(
-                                  Application.compile_env(
-                                    :concentrate,
-                                    [:group_filters, __MODULE__, :first_stop_delaying_statuses],
-                                    []
-                                  ),
-                                  &String.downcase/1
-                                )
+  @matching_statuses Enum.map(
+                       Application.compile_env(
+                         :concentrate,
+                         [:group_filters, __MODULE__, :matching_statuses],
+                         []
+                       ),
+                       &String.downcase/1
+                     )
   @downstream_status Application.compile_env(
                        :concentrate,
                        [:group_filters, __MODULE__, :downstream_status],
@@ -98,7 +98,7 @@ defmodule Concentrate.GroupFilter.PropogateDownstreamDelays do
   @spec first_status_only_stu([StopTimeUpdate.t()]) :: StopTimeUpdate.t() | nil
   defp first_status_only_stu(stus) do
     Enum.find(stus, fn stu ->
-      String.downcase(stu.status) in @first_stop_delaying_statuses &&
+      String.downcase(stu.status) in @matching_statuses &&
         stu.arrival_time == nil &&
         stu.departure_time == nil
     end)

--- a/test/concentrate/group_filter/propogate_downstream_delays_test.exs
+++ b/test/concentrate/group_filter/propogate_downstream_delays_test.exs
@@ -1,11 +1,9 @@
 defmodule Concentrate.GroupFilter.PropogateDownstreamDelaysTest do
   use ExUnit.Case, async: true
 
-  alias Concentrate.GTFS.FakeRoutes
-  alias Concentrate.GTFS.StopTimes
-  alias Concentrate.GroupFilter.PropogateDownstreamDelays
   alias Concentrate.Encoder.TripGroup
-
+  alias Concentrate.GroupFilter.PropogateDownstreamDelays
+  alias Concentrate.GTFS.{FakeRoutes, StopTimes}
   alias Concentrate.{StopTimeUpdate, TripDescriptor}
 
   defmodule FakeStopTimes do
@@ -71,7 +69,7 @@ defmodule Concentrate.GroupFilter.PropogateDownstreamDelaysTest do
       assert group == PropogateDownstreamDelays.filter(group, FakeStopTimes, FakeRoutes, now_fn)
     end
 
-    test "doesn't propagate delays if the first stop time update is not the first scheduled stop" do
+    test "doesn't propagate delays for stops before the first delayed stop" do
       td =
         TripDescriptor.new(
           trip_id: "trip",
@@ -80,7 +78,7 @@ defmodule Concentrate.GroupFilter.PropogateDownstreamDelaysTest do
           schedule_relationship: :SCHEDULED
         )
 
-      stu_1 =
+      stu_2 =
         StopTimeUpdate.new(
           trip_id: "trip",
           status: "Delayed",
@@ -88,11 +86,22 @@ defmodule Concentrate.GroupFilter.PropogateDownstreamDelaysTest do
           stop_sequence: 20
         )
 
-      group = %TripGroup{td: td, stus: [stu_1]}
+      group = %TripGroup{td: td, stus: [stu_2]}
 
       now_fn = fn -> 88_000 end
 
-      assert group == PropogateDownstreamDelays.filter(group, FakeStopTimes, FakeRoutes, now_fn)
+      assert %TripGroup{
+               td: td,
+               stus: [
+                 stu_2,
+                 StopTimeUpdate.new(
+                   trip_id: "trip",
+                   status: "Delayed",
+                   stop_id: "stop3",
+                   stop_sequence: 30
+                 )
+               ]
+             } == PropogateDownstreamDelays.filter(group, FakeStopTimes, FakeRoutes, now_fn)
     end
 
     test "adds stop time updates only when they don't already exist" do
@@ -140,7 +149,7 @@ defmodule Concentrate.GroupFilter.PropogateDownstreamDelaysTest do
              } == PropogateDownstreamDelays.filter(group, FakeStopTimes, FakeRoutes, now_fn)
     end
 
-    test "adds stop time updates only for scheduled arrivals in the past" do
+    test "adds stop time updates only for scheduled departures in the past" do
       td =
         TripDescriptor.new(
           trip_id: "trip",

--- a/test/concentrate/group_filter/propogate_downstream_delays_test.exs
+++ b/test/concentrate/group_filter/propogate_downstream_delays_test.exs
@@ -1,0 +1,178 @@
+defmodule Concentrate.GroupFilter.PropogateDownstreamDelaysTest do
+  use ExUnit.Case, async: true
+
+  alias Concentrate.GTFS.FakeRoutes
+  alias Concentrate.GTFS.StopTimes
+  alias Concentrate.GroupFilter.PropogateDownstreamDelays
+  alias Concentrate.Encoder.TripGroup
+
+  alias Concentrate.{StopTimeUpdate, TripDescriptor}
+
+  defmodule FakeStopTimes do
+    def stops_for_trip_with_arrival_departure("trip", _date),
+      do: [
+        {10, "stop1", 85_000, 85_001},
+        {20, "stop2", 86_000, 86_001},
+        {30, "stop3", 87_100, 87_101}
+      ]
+
+    def stops_for_trip_with_arrival_departure(_, _), do: :unknown
+  end
+
+  describe "filter/2" do
+    test "trip descriptor not scheduled" do
+      td =
+        TripDescriptor.new(
+          trip_id: "trip",
+          start_date: {2026, 1, 1},
+          schedule_relationship: :CANCELED
+        )
+
+      stu = StopTimeUpdate.new(trip_id: "trip", status: :CANCELED)
+
+      group = %TripGroup{td: td, stus: [stu]}
+
+      assert group == PropogateDownstreamDelays.filter(group)
+    end
+
+    test "doesn't propogate delays if the route is not commuter rail" do
+      td =
+        TripDescriptor.new(
+          trip_id: "trip",
+          route_id: "66",
+          start_date: {2026, 1, 1},
+          schedule_relationship: :SCHEDULED
+        )
+
+      stu = StopTimeUpdate.new(trip_id: "trip", status: "Delayed")
+
+      group = %TripGroup{td: td, stus: [stu]}
+
+      now_fn = fn -> 88_000 end
+
+      assert group == PropogateDownstreamDelays.filter(group, StopTimes, FakeRoutes, now_fn)
+    end
+
+    test "doesn't propogate delays if the first stop time status isn't in delaying status list" do
+      td =
+        TripDescriptor.new(
+          trip_id: "trip",
+          route_id: "CR_1",
+          start_date: {2026, 1, 1},
+          schedule_relationship: :SCHEDULED
+        )
+
+      stu_1 = StopTimeUpdate.new(trip_id: "trip", status: "On time", stop_sequence: 10)
+
+      group = %TripGroup{td: td, stus: [stu_1]}
+
+      now_fn = fn -> 88_000 end
+
+      assert group == PropogateDownstreamDelays.filter(group, FakeStopTimes, FakeRoutes, now_fn)
+    end
+
+    test "doesn't propagate delays if the first stop time update is not the first scheduled stop" do
+      td =
+        TripDescriptor.new(
+          trip_id: "trip",
+          route_id: "CR_1",
+          start_date: {2026, 1, 1},
+          schedule_relationship: :SCHEDULED
+        )
+
+      stu_1 =
+        StopTimeUpdate.new(
+          trip_id: "trip",
+          status: "Delayed",
+          stop_id: "stop2",
+          stop_sequence: 20
+        )
+
+      group = %TripGroup{td: td, stus: [stu_1]}
+
+      now_fn = fn -> 88_000 end
+
+      assert group == PropogateDownstreamDelays.filter(group, FakeStopTimes, FakeRoutes, now_fn)
+    end
+
+    test "adds stop time updates only when they don't already exist" do
+      td =
+        TripDescriptor.new(
+          trip_id: "trip",
+          route_id: "CR_1",
+          start_date: {2026, 1, 1},
+          schedule_relationship: :SCHEDULED
+        )
+
+      stu_1 =
+        StopTimeUpdate.new(
+          trip_id: "trip",
+          status: "Delayed",
+          stop_id: "stop1",
+          stop_sequence: 10
+        )
+
+      stu_2 =
+        StopTimeUpdate.new(
+          trip_id: "trip",
+          arrival_time: 86_000,
+          departure_time: 86_001,
+          stop_id: "stop2",
+          stop_sequence: 20
+        )
+
+      group = %TripGroup{td: td, stus: [stu_1, stu_2]}
+
+      now_fn = fn -> 88_000 end
+
+      assert %TripGroup{
+               td: td,
+               stus: [
+                 stu_1,
+                 stu_2,
+                 StopTimeUpdate.new(
+                   trip_id: "trip",
+                   status: "Delayed",
+                   stop_id: "stop3",
+                   stop_sequence: 30
+                 )
+               ]
+             } == PropogateDownstreamDelays.filter(group, FakeStopTimes, FakeRoutes, now_fn)
+    end
+
+    test "adds stop time updates only for scheduled arrivals in the past" do
+      td =
+        TripDescriptor.new(
+          trip_id: "trip",
+          route_id: "CR_1",
+          start_date: {2026, 1, 1},
+          schedule_relationship: :SCHEDULED
+        )
+
+      stu_1 =
+        StopTimeUpdate.new(
+          trip_id: "trip",
+          status: "Delayed",
+          stop_id: "stop1",
+          stop_sequence: 10
+        )
+
+      group = %TripGroup{td: td, stus: [stu_1]}
+
+      now_fn = fn -> 86_500 end
+
+      assert %TripGroup{
+               td: td,
+               stus: [
+                 stu_1,
+                 StopTimeUpdate.new(
+                   trip_id: "trip",
+                   status: "Delayed",
+                   stop_id: "stop2",
+                   stop_sequence: 20
+                 )
+               ]
+             } == PropogateDownstreamDelays.filter(group, FakeStopTimes, FakeRoutes, now_fn)
+    end
+  end
+end

--- a/test/support/filter/fakes.ex
+++ b/test/support/filter/fakes.ex
@@ -9,6 +9,9 @@ end
 
 defmodule Concentrate.GTFS.FakeRoutes do
   @moduledoc "Fake implementation of GTFS.Routes"
+
+  def route_type("CR" <> _), do: 2
+
   def route_type(route_id) when is_binary(route_id) do
     case Integer.parse(route_id) do
       :error -> nil


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [CR Delays | Concentrate change to propagate status when delays](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1218067460223114?focus=true)

This adds a new GroupFilter to propagate delay StopTimeUpdates under certain circumstances:
* CR trips only
* There is a status-only StopTimeUpdate indicating a delay
* For downstream stops that have scheduled departure in the past and no existing StopTimeUpdate

So far I have only unit tested this and am not sure how to best test it end-to-end (are we able to mock status-only delay STUs coming from Keolis?)


Note: I used AI for autocompleting helper functions and generating test stubs.
